### PR TITLE
fix(auth): defer resource binding for dynamic clients

### DIFF
--- a/internal/handlers/oauth_mcp.go
+++ b/internal/handlers/oauth_mcp.go
@@ -90,8 +90,11 @@ type dynamicClientRegistrationResponse struct {
 }
 
 // RegisterDynamicClient implements a constrained RFC 7591 registration
-// endpoint for MCP clients. It creates public clients only: authorization-code
-// plus refresh-token grants, S256 PKCE, and HTTPS or loopback callbacks.
+// endpoint for public OAuth clients. It creates public clients only:
+// authorization-code plus refresh-token grants, S256 PKCE, and HTTPS or
+// loopback callbacks. Registration does not select a protected-resource
+// audience; clients that need one (such as MCP clients) bind it on the
+// authorization request via RFC 8707's resource parameter.
 func (h *OAuthHandler) RegisterDynamicClient(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, oauthRegistrationMaxBytes)
 	var req dynamicClientRegistrationRequest
@@ -117,15 +120,15 @@ func (h *OAuthHandler) RegisterDynamicClient(w http.ResponseWriter, r *http.Requ
 	}
 	displayName := strings.TrimSpace(req.ClientName)
 	if displayName == "" {
-		displayName = "MCP client"
+		displayName = "OAuth client"
 	}
-	slug := "mcp-" + strings.TrimPrefix(clientID, "wsoc_")[:16]
+	slug := "oauth-" + strings.TrimPrefix(clientID, "wsoc_")[:16]
 	redirectsJSON, _ := json.Marshal(req.RedirectURIs)
 	allowedScopes := nonAdminOAuthScopes()
 	scopesJSON, _ := json.Marshal(allowedScopes)
 
 	err = repository.NewOAuthClientRepository(h.db).CreateDynamicPublicClient(
-		slug, displayName, clientID, string(redirectsJSON), string(scopesJSON), h.mcpResourceURI,
+		slug, displayName, clientID, string(redirectsJSON), string(scopesJSON), "",
 	)
 	if err != nil {
 		if errors.Is(err, repository.ErrDuplicateEntry) {


### PR DESCRIPTION
## Summary
- make RFC 7591 registrations resource-neutral instead of binding every public client to /mcp
- let each authorization request select its resource through RFC 8707
- use provider-neutral names and slugs for dynamically registered clients

This enables Docmost to use a per-user public OAuth flow without an MCP audience. Omni is unchanged and continues to send /mcp during authorization, token exchange, and refresh.

## Tests
- full internal/handlers overlay suite (passed)
- focused dynamic-registration regression after rebasing onto main (passed)
- Omni Windshift connector: 3 passed
- Omni connector OAuth integration: 5 passed

The matching regression test is on Windshiftapp/core-tests branch feat/docmost-public-oauth.