### PR TITLE
refactor(frontend): decompose MainApp shell (WI-980)

### DIFF
--- a/frontend/src/lib/pages/MainApp.svelte
+++ b/frontend/src/lib/pages/MainApp.svelte
@@ -1,61 +1,48 @@
 <script>
-  import { onMount } from 'svelte';
   import { slide } from 'svelte/transition';
-  import { currentRoute, navigate, isWorkspaceRoute, GLOBAL_COLLECTION_VIEWS } from '../router.js';
-  import { authStore, permissionStore, uiStore, currentWorkspace, workspacesStore, workspacePermissions, ssoStore, workspaceDataStore, activityStore, collectionStore, homepageStore } from '../stores';
-  import EmailVerificationBanner from '../features/notifications/EmailVerificationBanner.svelte';
-  import { moduleSettings } from '../stores/moduleSettings.js';
-  import { aiStore } from '../stores/aiStore.svelte.js';
-  import { chatStore } from '../stores/chatStore.svelte.js';
-  import { capabilitiesStore } from '../stores/capabilities.svelte.js';
-  import { startNotificationPoller, stopNotificationPoller } from '../stores/notifications.js';
-  import { resetAuthenticatedShellState, runAuthenticatedShellBootstrap } from '../services/authenticatedShellBootstrap.js';
-  import { hydrateAuthenticatedShellUI, hydrateCurrentWorkspaceFromSharedData, refreshAuthenticatedShellUI } from '../services/authenticatedShellUI.js';
-  import { desktopBridge } from '../desktop/bridge.svelte.js';
-  import { initDesktopFocusRefresh } from '../utils/desktopFocusRefresh.svelte.js';
-  import { api } from '../api.js';
-  import { ADMIN_UI_MUTATION_EVENT } from '../api/core.js';
-  import { t } from '../stores/i18n.svelte.js';
-  import NotFound from './NotFound.svelte';
-  import Workspaces from '../workspaces/Workspaces.svelte';
-  import WorkspaceSettings from '../workspaces/WorkspaceSettings.svelte';
-  import Collections from '../features/collections/Collections.svelte';
-  import CollectionsList from '../features/collections/CollectionsList.svelte';
-  import NotificationsPage from './NotificationsPage.svelte';
-  import ApprovalsInbox from './ApprovalsInbox.svelte';
-  import UserProfile from './UserProfile.svelte';
-  import Security from './Security.svelte';
-  import SearchPage from './SearchPage.svelte';
-  import About from './About.svelte';
-  import ApiDocs from './ApiDocs.svelte';
-  import CliAuthorize from './CliAuthorize.svelte';
-  import OAuthAuthorize from './OAuthAuthorize.svelte';
-  import Channels from '../features/channels/Channels.svelte';
-  import Customers from '../workspaces/Customers.svelte';
-  import TeamsList from '../teams/TeamsList.svelte';
-  import TeamDetail from '../teams/TeamDetail.svelte';
-  import Hub from '../layout/Hub.svelte';
-  import Footer from '../layout/Footer.svelte';
-  import {
-    Layers3, BarChart3, Sheet, Target, User, Notebook, GitBranch, MapPin, Shield, Home, CheckSquare, MoreHorizontal, Inbox, SquareKanban, FolderOpen, Menu
-  } from '@lucide/svelte';
-  import GlobalConfirmDialog from '../dialogs/GlobalConfirmDialog.svelte';
-  import FloatingTimer from '../features/time/FloatingTimer.svelte';
-  import ToastContainer from '../features/notifications/ToastContainer.svelte';
-  import Spinner from '../components/Spinner.svelte';
-  import ModalBackdrop from '../components/ModalBackdrop.svelte';
-  import Button from '../components/Button.svelte';
-  import PermissionGuard from '../layout/PermissionGuard.svelte';
-  import UnauthorizedAccess from './UnauthorizedAccess.svelte';
-  import WorkspaceNavigation from '../workspaces/WorkspaceNavigation.svelte';
-  import CollectionNavigation from '../features/collections/CollectionNavigation.svelte';
-  import { clearWorkspaceGradient } from '../stores/workspaceGradient.svelte.js';
+  import { Menu } from '@lucide/svelte';
   import { useEventListener } from 'runed';
+  import { api } from '../api.js';
+  import Button from '../components/Button.svelte';
+  import Spinner from '../components/Spinner.svelte';
+  import EmailVerificationBanner from '../features/notifications/EmailVerificationBanner.svelte';
+  import CollectionNavigation from '../features/collections/CollectionNavigation.svelte';
+  import Footer from '../layout/Footer.svelte';
+  import MainSidebar from '../layout/MainSidebar.svelte';
+  import {
+    GLOBAL_COLLECTION_VIEWS,
+    currentRoute,
+    isWorkspaceRoute,
+    navigate,
+  } from '../router.js';
+  import { hydrateCurrentWorkspaceFromSharedData } from '../services/authenticatedShellUI.js';
+  import {
+    authStore,
+    currentWorkspace,
+    uiStore,
+    workspaceDataStore,
+    workspacesStore,
+  } from '../stores';
+  import { aiStore } from '../stores/aiStore.svelte.js';
+  import { terminalStore } from '../stores/terminalStore.svelte.js';
+  import { clearWorkspaceGradient } from '../stores/workspaceGradient.svelte.js';
   import { toHotkeyString } from '../utils/keyboardShortcuts.js';
   import { LazyComponentLoader } from '../utils/lazyComponentLoader.svelte.js';
   import { hasSessionExpired, reloadIfBuildChanged } from '../utils/lazyLoadRecovery.js';
-  import MainSidebar from '../layout/MainSidebar.svelte';
-  import { terminalStore } from '../stores/terminalStore.svelte.js';
+  import WorkspaceNavigation from '../workspaces/WorkspaceNavigation.svelte';
+  import MainAppOverlays from './MainAppOverlays.svelte';
+  import MainRouteContent from './MainRouteContent.svelte';
+  import { useMainAppLifecycle } from './useMainAppLifecycle.js';
+  import {
+    CREATE_MODAL_WORKSPACE_VIEWS,
+    MAIN_APP_COMPONENT_LOADERS,
+    MAIN_APP_TEST_VIEWS,
+    resolveEffectiveMainAppView,
+  } from './mainAppRoutes.js';
+  import {
+    getMainAppWorkspaceRedirect,
+    resolveMainAppWorkspaceContext,
+  } from './mainAppWorkspaceContext.js';
 
   let showCommandPalette = $state(false);
   let showCreateModal = $state(false);
@@ -66,16 +53,21 @@
   let showEmailVerificationBanner = $state(false);
   let mobileWorkspaceNavOpen = $state(false);
 
-  // Terminal panel state
   let terminalState = $derived($terminalStore);
   let TerminalPanelComponent = $state(null);
   let terminalLoading = $state(false);
   let isResizingTerminal = $state(false);
   let resizeStartX = $state(0);
   let resizeStartPercent = $state(50);
-  let PomodoroSettingsModalComponent = $state(null);
-  let AboutModalComponent = $state(null);
-  let desktopModalLoading = $state(false);
+
+  let sessionRevalidationPromise = null;
+
+  const lazyComponents = new LazyComponentLoader(MAIN_APP_COMPONENT_LOADERS, {
+    onError: (view, error) => {
+      console.error(`Failed to load component for ${view}:`, error);
+      void recoverFromLazyLoadFailure();
+    },
+  });
 
   async function loadTerminalPanel() {
     if (TerminalPanelComponent || terminalLoading) return;
@@ -83,8 +75,8 @@
     try {
       const module = await import('../features/terminal/TerminalPanel.svelte');
       TerminalPanelComponent = module.default;
-    } catch (err) {
-      console.error('Failed to load terminal panel:', err);
+    } catch (error) {
+      console.error('Failed to load terminal panel:', error);
     } finally {
       terminalLoading = false;
     }
@@ -92,47 +84,22 @@
 
   function toggleTerminal() {
     terminalStore.toggle();
-    if (!TerminalPanelComponent) {
-      loadTerminalPanel();
-    }
+    if (!TerminalPanelComponent) void loadTerminalPanel();
   }
 
-  async function loadDesktopModal(modal) {
-    if (desktopModalLoading) return;
-    if (modal === 'pomodoro-settings' && PomodoroSettingsModalComponent) return;
-    if (modal === 'about' && AboutModalComponent) return;
-
-    desktopModalLoading = true;
-    try {
-      if (modal === 'pomodoro-settings') {
-        const module = await import('../dialogs/PomodoroSettingsModal.svelte');
-        PomodoroSettingsModalComponent = module.default;
-      } else if (modal === 'about') {
-        const module = await import('../dialogs/AboutModal.svelte');
-        AboutModalComponent = module.default;
-      }
-    } catch (err) {
-      console.error('Failed to load desktop modal:', err);
-    } finally {
-      desktopModalLoading = false;
-    }
-  }
-
-  function handleTerminalResizeStart(e) {
-    e.preventDefault();
-    resizeStartX = e.clientX;
+  function handleTerminalResizeStart(event) {
+    event.preventDefault();
+    resizeStartX = event.clientX;
     resizeStartPercent = terminalState.splitPercent;
     isResizingTerminal = true;
   }
 
-  function onTerminalMouseMove(e) {
+  function onTerminalMouseMove(event) {
     const container = document.querySelector('.main-split-container');
     if (!container) return;
     const rect = container.getBoundingClientRect();
-    const deltaX = e.clientX - resizeStartX;
-    const deltaPercent = (deltaX / rect.width) * 100;
-    const newPercent = resizeStartPercent + deltaPercent;
-    terminalStore.setSplitPercent(newPercent);
+    const deltaX = event.clientX - resizeStartX;
+    terminalStore.setSplitPercent(resizeStartPercent + (deltaX / rect.width) * 100);
   }
 
   function onTerminalMouseUp() {
@@ -152,117 +119,6 @@
     };
   });
 
-  let lastSpaceTime = 0;
-  let sessionRevalidationPromise = null;
-  let adminUIRefreshTimer = null;
-  let adminUIRefreshPromise = null;
-  let adminUIRefreshQueued = false;
-  const DOUBLE_SPACE_THRESHOLD = 300; // milliseconds
-  const ADMIN_UI_REFRESH_DEBOUNCE_MS = 75;
-
-  async function runAdminUIRefresh() {
-    if (adminUIRefreshPromise) {
-      adminUIRefreshQueued = true;
-      return adminUIRefreshPromise;
-    }
-
-    do {
-      adminUIRefreshQueued = false;
-      adminUIRefreshPromise = refreshAuthenticatedShellUI();
-      try {
-        await adminUIRefreshPromise;
-      } finally {
-        adminUIRefreshPromise = null;
-      }
-    } while (adminUIRefreshQueued);
-  }
-
-  function scheduleAdminUIRefresh() {
-    if (adminUIRefreshTimer) clearTimeout(adminUIRefreshTimer);
-    adminUIRefreshTimer = setTimeout(() => {
-      adminUIRefreshTimer = null;
-      void runAdminUIRefresh();
-    }, ADMIN_UI_REFRESH_DEBOUNCE_MS);
-  }
-
-  // Security and other late-mounted consumers can await the shell feature
-  // snapshot instead of racing it with a second /api/features request.
-  capabilitiesStore.beginHydration();
-
-  // Component loaders with literal import paths for Vite's static analysis
-  const componentLoaders = {
-    'admin': () => import('./Admin.svelte'),
-    'time': () => import('../features/time/Time.svelte'),
-    'test-cases': () => import('../features/testing/TestCases.svelte'),
-    'test-sets': () => import('../features/testing/TestSets.svelte'),
-    'test-templates': () => import('../features/testing/TestTemplates.svelte'),
-    'test-runs': () => import('../features/testing/TestRuns.svelte'),
-    'test-reports': () => import('../features/testing/TestReports.svelte'),
-    'test-steps': () => import('../features/testing/TestSteps.svelte'),
-    'test-execution': () => import('../features/testing/TestExecution.svelte'),
-    'test-run-detail': () => import('../features/testing/TestRunDetail.svelte'),
-    'test-template-detail': () => import('../features/testing/TestTemplateDetail.svelte'),
-    'milestones': () => import('../features/milestones/Milestones.svelte'),
-    'milestone-detail': () => import('../features/milestones/MilestoneDetail.svelte'),
-    'iterations': () => import('../features/iterations/Iterations.svelte'),
-    'iteration-detail': () => import('../features/iterations/IterationDetail.svelte'),
-    'iteration-dependencies': () => import('../features/iterations/IterationDependencies.svelte'),
-    'assets': () => import('../features/assets/AssetBrowser.svelte'),
-    'asset-detail': () => import('../features/assets/AssetBrowser.svelte'),
-    'asset-settings': () => import('../features/assets/AssetManager.svelte'),
-    'channel-manager': () => import('../features/channels/ManagerChannels.svelte'),
-    'workspace-board': () => import('../features/collections/CollectionBoard.svelte'),
-    'workspace-board-config': () => import('../settings/BoardConfigurationPage.svelte'),
-    'workspace-backlog': () => import('../features/collections/CollectionBacklog.svelte'),
-    'workspace-list': () => import('../features/collections/CollectionList.svelte'),
-    'workspace-tree': () => import('../features/collections/CollectionTree.svelte'),
-    'workspace-map': () => import('../features/collections/CollectionMap.svelte'),
-    'workspace-roadmap': () => import('../features/collections/CollectionRoadmap.svelte'),
-    'workspace-pages': () => import('../features/pages/PagesView.svelte'),
-    'workspace-pages-archived': () => import('../features/pages/ArchivedPagesPage.svelte'),
-    // Global collection views (no workspace)
-    'collection-board': () => import('../features/collections/CollectionBoard.svelte'),
-    'collection-board-config': () => import('../settings/BoardConfigurationPage.svelte'),
-    'collection-backlog': () => import('../features/collections/CollectionBacklog.svelte'),
-    'collection-list': () => import('../features/collections/CollectionList.svelte'),
-    'collection-tree': () => import('../features/collections/CollectionTree.svelte'),
-    'collection-map': () => import('../features/collections/CollectionMap.svelte'),
-    'collection-roadmap': () => import('../features/collections/CollectionRoadmap.svelte'),
-    'workspace-iterations': () => import('../features/iterations/Iterations.svelte'),
-    'workspace-milestones': () => import('../features/milestones/Milestones.svelte'),
-    'workspace-actions': () => import('../features/actions/ActionsSettings.svelte'),
-    'workspace-analytics': () => import('../features/analytics/WorkspaceAnalytics.svelte'),
-    'workspace-agents': () => import('../features/agents/AgentCatalog.svelte'),
-    'workspace-agent-create': () => import('../features/agents/AgentCreate.svelte'),
-    'workspace-agent-profile': () => import('../features/agents/AgentProfile.svelte'),
-    'command-palette': () => import('../layout/CommandPalette.svelte'),
-    'create-modal': () => import('../dialogs/CreateModal.svelte'),
-    'homepage': () => import('./Homepage.svelte'),
-    'licenses': () => import('./Licenses.svelte'),
-    'item-detail': () => import('../features/items/ItemDetail.svelte'),
-    'personal-task-detail': () => import('../features/personal/PersonalTaskDetail.svelte'),
-    'workspace-detail': () => import('../workspaces/WorkspaceWelcome.svelte'),
-    'workspace-overview': () => import('../workspaces/WorkspaceWelcome.svelte'),
-    'personal-workspace': () => import('../workspaces/WorkspaceDetail.svelte'),
-    'workspace-calendar': () => import('../features/time/WeeklyCalendar.svelte'),
-    'workspace-reviews': () => import('../features/personal/PersonalReview.svelte'),
-    'workflow-designer': () => import('../features/workflows/WorkflowDesigner.svelte'),
-    'configuration-set-detail': () => import('../settings/ConfigurationSetDetail.svelte'),
-    'workspace-look-and-feel': () => import('../workspaces/WorkspaceLookAndFeel.svelte'),
-    'personal-plan': () => import('../features/personal/PlanMyDay.svelte'),
-    'logbook': () => import('../features/logbook/Logbook.svelte'),
-    'logbook-document': () => import('../features/logbook/DocumentDetail.svelte'),
-    'chat-panel': () => import('../features/chat/ChatPanel.svelte'),
-    'terminal-panel': () => import('../features/terminal/TerminalPanel.svelte')
-  };
-
-  const lazyComponents = new LazyComponentLoader(componentLoaders, {
-    onError: (view, error) => {
-      console.error(`Failed to load component for ${view}:`, error);
-      void recoverFromLazyLoadFailure();
-    },
-  });
-
   async function recoverFromLazyLoadFailure() {
     if (!authStore.isAuthenticated) return;
 
@@ -271,8 +127,6 @@
     sessionRevalidationPromise = null;
 
     if (sessionExpired) {
-      // fetchAPI also clears auth on a 401. Keep this explicit so the recovery
-      // contract remains correct if the session check implementation changes.
       authStore.clearAuth();
       showCommandPalette = false;
       closeCreateModal();
@@ -280,9 +134,6 @@
       return;
     }
 
-    // The session is fine, so the chunk itself is gone: a deploy replaced every
-    // hashed filename this tab knows about. Reload onto the new build rather
-    // than leaving the requested view stuck on its error state.
     await reloadIfBuildChanged();
   }
 
@@ -293,593 +144,57 @@
     createModalWorkspaceId = null;
   }
 
-  // Route configuration for lazy-loaded components (metadata only)
-  const routeConfig = {
-    'admin': {
-      loadingMsg: 'Loading Admin Panel...',
-      errorMsg: 'Failed to load Admin Panel',
-      requirePermission: 'systemAdmin'
-    },
-    'time': {
-      loadingMsg: 'Loading Time & Projects...',
-      errorMsg: 'Failed to load Time & Projects'
-    },
-    'test-cases': {
-      loadingMsg: 'Loading Test Cases...',
-      errorMsg: 'Failed to load Test Cases',
-      wrapper: 'none',
-      getProps: (route) => ({ workspaceId: route.params.id })
-    },
-    'test-sets': {
-      loadingMsg: 'Loading Test Plans...',
-      errorMsg: 'Failed to load Test Plans',
-      wrapper: 'none',
-      getProps: (route) => ({ workspaceId: route.params.id })
-    },
-    'test-templates': {
-      loadingMsg: 'Loading Test Templates...',
-      errorMsg: 'Failed to load Test Templates',
-      wrapper: 'none',
-      getProps: (route) => ({ workspaceId: route.params.id })
-    },
-    'test-runs': {
-      loadingMsg: 'Loading Test Runs...',
-      errorMsg: 'Failed to load Test Runs',
-      wrapper: 'none',
-      getProps: (route) => ({ workspaceId: route.params.id })
-    },
-    'test-reports': {
-      loadingMsg: 'Loading Test Reports...',
-      errorMsg: 'Failed to load Test Reports',
-      wrapper: 'none',
-      getProps: (route) => ({ workspaceId: route.params.id })
-    },
-    'test-steps': {
-      loadingMsg: 'Loading Test Steps...',
-      errorMsg: 'Failed to load Test Steps',
-      wrapper: 'none',
-      getProps: (route) => ({ workspaceId: route.params.id })
-    },
-    'test-execution': {
-      loadingMsg: 'Loading Test Execution...',
-      errorMsg: 'Failed to load Test Execution',
-      wrapper: 'none'
-    },
-    'test-run-detail': {
-      loadingMsg: 'Loading Test Run Details...',
-      errorMsg: 'Failed to load Test Run Details',
-      wrapper: 'none'
-    },
-    'test-template-detail': {
-      loadingMsg: 'Loading Template Details...',
-      errorMsg: 'Failed to load Template Details',
-      wrapper: 'none'
-    },
-    'milestones': {
-      loadingMsg: 'Loading Milestones...',
-      errorMsg: 'Failed to load Milestones',
-      wrapper: 'surface-full'
-    },
-    'milestone-detail': {
-      loadingMsg: 'Loading Milestone...',
-      errorMsg: 'Failed to load Milestone',
-      wrapper: 'surface-full',
-      getProps: (route) => ({
-        milestoneId: route.params.id,
-        workspaceId: route.query?.workspaceId || null
-      })
-    },
-    'iterations': {
-      loadingMsg: 'Loading Iterations...',
-      errorMsg: 'Failed to load Iterations',
-      wrapper: 'surface-full',
-      getProps: (route) => ({ typeId: route.params.typeId })
-    },
-    'iteration-detail': {
-      loadingMsg: 'Loading Iteration...',
-      errorMsg: 'Failed to load Iteration',
-      wrapper: 'surface-full',
-      getProps: (route) => ({
-        iterationId: route.params.id,
-        workspaceId: route.query?.workspaceId || null
-      })
-    },
-    'iteration-dependencies': {
-      loadingMsg: 'Loading Dependency Analysis...',
-      errorMsg: 'Failed to load Dependency Analysis',
-      wrapper: 'surface-full',
-      getProps: (route) => ({
-        iterationId: route.params.id,
-      })
-    },
-    'assets': {
-      loadingMsg: 'Loading Assets...',
-      errorMsg: 'Failed to load Assets',
-      wrapper: 'surface-full'
-    },
-    'channel-manager': {
-      loadingMsg: 'Loading Channels...',
-      errorMsg: 'Failed to load Channels',
-      wrapper: 'surface-padded'
-    },
-    'asset-detail': {
-      loadingMsg: 'Loading Asset...',
-      errorMsg: 'Failed to load Asset',
-      wrapper: 'surface-full',
-      getProps: (route) => ({ assetId: route.params.id })
-    },
-    'asset-settings': {
-      loadingMsg: 'Loading Asset Settings...',
-      errorMsg: 'Failed to load Asset Settings',
-      wrapper: 'surface-admin'
-    },
-    'workspace-board': {
-      loadingMsg: 'Loading Board View...',
-      errorMsg: 'Failed to load Board View',
-      getProps: (route) => ({ workspaceId: route.params.id, collectionId: route.params.collectionId })
-    },
-    'workspace-board-config': {
-      loadingMsg: 'Loading Board Configuration...',
-      errorMsg: 'Failed to load Board Configuration',
-      getProps: (route) => ({ workspaceId: route.params.id, collectionId: route.params.collectionId })
-    },
-    'workspace-backlog': {
-      loadingMsg: 'Loading Backlog View...',
-      errorMsg: 'Failed to load Backlog View',
-      getProps: (route) => ({ workspaceId: route.params.id, collectionId: route.params.collectionId })
-    },
-    'workspace-list': {
-      loadingMsg: 'Loading List View...',
-      errorMsg: 'Failed to load List View',
-      getProps: (route) => ({ workspaceId: route.params.id, collectionId: route.params.collectionId })
-    },
-    'workspace-tree': {
-      loadingMsg: 'Loading Tree View...',
-      errorMsg: 'Failed to load Tree View',
-      getProps: (route) => ({ workspaceId: route.params.id, collectionId: route.params.collectionId })
-    },
-    'workspace-map': {
-      loadingMsg: 'Loading Map View...',
-      errorMsg: 'Failed to load Map View',
-      getProps: (route) => ({ workspaceId: route.params.id, collectionId: route.params.collectionId })
-    },
-    'workspace-roadmap': {
-      loadingMsg: 'Loading Roadmap...',
-      errorMsg: 'Failed to load Roadmap',
-      getProps: (route) => ({ workspaceId: route.params.id, collectionId: route.params.collectionId })
-    },
-    'workspace-pages': {
-      loadingMsg: 'Loading Pages...',
-      errorMsg: 'Failed to load Pages',
-      wrapper: 'none',
-      getProps: (route) => ({
-        workspaceId: Number(route.params.id),
-        pageId: route.params.pageId ? Number(route.params.pageId) : null,
-      })
-    },
-    'workspace-pages-archived': {
-      loadingMsg: 'Loading Archived Pages...',
-      errorMsg: 'Failed to load Archived Pages',
-      wrapper: 'none',
-      getProps: (route) => ({ workspaceId: Number(route.params.id) })
-    },
-    // Global collection views (no workspace)
-    'collection-board': {
-      loadingMsg: 'Loading Board View...',
-      errorMsg: 'Failed to load Board View',
-      getProps: (route) => ({ workspaceId: null, collectionId: route.params.id })
-    },
-    'collection-board-config': {
-      loadingMsg: 'Loading Board Configuration...',
-      errorMsg: 'Failed to load Board Configuration',
-      getProps: (route) => ({ workspaceId: null, collectionId: route.params.id })
-    },
-    'collection-backlog': {
-      loadingMsg: 'Loading Backlog View...',
-      errorMsg: 'Failed to load Backlog View',
-      getProps: (route) => ({ workspaceId: null, collectionId: route.params.id })
-    },
-    'collection-list': {
-      loadingMsg: 'Loading List View...',
-      errorMsg: 'Failed to load List View',
-      getProps: (route) => ({ workspaceId: null, collectionId: route.params.id })
-    },
-    'collection-tree': {
-      loadingMsg: 'Loading Tree View...',
-      errorMsg: 'Failed to load Tree View',
-      getProps: (route) => ({ workspaceId: null, collectionId: route.params.id })
-    },
-    'collection-map': {
-      loadingMsg: 'Loading Map View...',
-      errorMsg: 'Failed to load Map View',
-      getProps: (route) => ({ workspaceId: null, collectionId: route.params.id })
-    },
-    'collection-roadmap': {
-      loadingMsg: 'Loading Roadmap...',
-      errorMsg: 'Failed to load Roadmap',
-      getProps: (route) => ({ workspaceId: null, collectionId: route.params.id })
-    },
-    'workspace-iterations': {
-      loadingMsg: 'Loading Iterations...',
-      errorMsg: 'Failed to load Iterations',
-      wrapper: 'surface-full',
-      getProps: (route) => ({ workspaceId: route.params.id })
-    },
-    'workspace-milestones': {
-      loadingMsg: 'Loading Milestones...',
-      errorMsg: 'Failed to load Milestones',
-      wrapper: 'surface-full',
-      getProps: (route) => ({ workspaceId: route.params.id })
-    },
-    'workspace-actions': {
-      loadingMsg: 'Loading Actions...',
-      errorMsg: 'Failed to load Actions',
-      wrapper: 'none',
-      getProps: (route) => ({
-        workspaceId: route.params.id,
-        actionId: Number(route.params.actionId) || 0,
-      })
-    },
-    'workspace-analytics': {
-      loadingMsg: 'Loading Analytics...',
-      errorMsg: 'Failed to load Analytics',
-      wrapper: 'surface-full',
-      getProps: (route) => ({ workspaceId: route.params.id })
-    },
-    'workspace-agents': {
-      loadingMsg: 'Loading Agents...',
-      errorMsg: 'Failed to load Agents',
-      wrapper: 'surface-full',
-      getProps: (route) => ({ workspaceId: route.params.id })
-    },
-    'workspace-agent-create': {
-      loadingMsg: 'Opening Agent Studio...',
-      errorMsg: 'Failed to open Agent Studio',
-      wrapper: 'surface-full',
-      getProps: (route) => ({ workspaceId: route.params.id })
-    },
-    'workspace-agent-profile': {
-      loadingMsg: 'Loading Agent...',
-      errorMsg: 'Failed to load Agent',
-      wrapper: 'surface-full',
-      getProps: (route) => ({
-        workspaceId: route.params.id,
-        agentId: route.params.agentId,
-        tab: route.query?.tab,
-      })
-    },
-    'command-palette': {
-      trigger: 'showCommandPalette'
-    },
-    'create-modal': {
-      trigger: 'showCreateModal'
-    },
-    'homepage': {
-      loadingMsg: 'Loading Homepage...',
-      errorMsg: 'Failed to load Homepage',
-      wrapper: 'surface-full'
-    },
-    'licenses': {
-      loadingMsg: 'Loading Licenses...',
-      errorMsg: 'Failed to load Licenses',
-      wrapper: 'surface-full'
-    },
-    'item-detail': {
-      loadingMsg: 'Loading Item Details...',
-      errorMsg: 'Failed to load Item Details',
-      getProps: (route) => {
-        const personal = route.path.startsWith('/personal');
-        const workspaceParam = route.params.workspaceKey || route.params.id;
-        const itemParam = route.params.itemKey || route.params.itemNumber || route.params.itemId;
-        const fullKeyMatch = !personal ? String(itemParam || '').match(/^([^/\s-]+)-(\d+)$/) : null;
-        const workspaceParamIsKey = !!workspaceParam && !/^\d+$/.test(String(workspaceParam));
-        const keyWorkspace = fullKeyMatch?.[1] || (workspaceParamIsKey ? workspaceParam : null);
-        const keyItemNumber = fullKeyMatch?.[2] || (keyWorkspace ? itemParam : null);
-        return {
-          workspaceId: personal ? $workspacesStore.personalWorkspace?.id : (keyWorkspace ? null : workspaceParam),
-          itemId: keyItemNumber || itemParam,
-          workspaceKey: !personal ? keyWorkspace : null,
-          itemNumber: !personal ? keyItemNumber : null,
-          canonicalizeKeyRoute: !personal && !!keyWorkspace,
-          tab: route.query.tab || 'comments',
-          moduleSettings: $moduleSettings
-        };
-      }
-    },
-    'personal-task-detail': {
-      loadingMsg: 'Loading Task...',
-      errorMsg: 'Failed to load Task',
-      getProps: (route) => ({
-        workspaceId: route.path.startsWith('/personal') ? $workspacesStore.personalWorkspace?.id : route.params.id,
-        itemId: route.params.itemId,
-        isModal: false
-      })
-    },
-    'workspace-detail': {
-      loadingMsg: 'Loading Workspace...',
-      errorMsg: 'Failed to load Workspace',
-      getProps: (route) => ({ workspaceId: route.params.id, collectionId: route.params.collectionId })
-    },
-    'workspace-overview': {
-      loadingMsg: 'Loading Workspace...',
-      errorMsg: 'Failed to load Workspace',
-      getProps: (route) => ({ workspaceId: route.params.id, collectionId: route.params.collectionId })
-    },
-    'personal-workspace': {
-      loadingMsg: 'Loading Personal Workspace...',
-      errorMsg: 'Failed to load Personal Workspace',
-      getProps: () => ({ workspaceId: $workspacesStore.personalWorkspace?.id })
-    },
-    'workspace-calendar': {
-      loadingMsg: 'Loading Calendar...',
-      errorMsg: 'Failed to load Calendar',
-      wrapper: 'surface-full',
-      getProps: (route) => ({
-        workspaceId: route.path.startsWith('/personal') ? $workspacesStore.personalWorkspace?.id : route.params.id
-      })
-    },
-    'workspace-reviews': {
-      loadingMsg: 'Loading Reviews...',
-      errorMsg: 'Failed to load Reviews',
-      wrapper: 'surface-full',
-      getProps: (route) => ({
-        currentUser: authStore.currentUser,
-        workspaceId: route.path.startsWith('/personal') ? $workspacesStore.personalWorkspace?.id : route.params.id
-      })
-    },
-    'workflow-designer': {
-      loadingMsg: 'Loading workflow designer...',
-      errorMsg: 'Failed to load workflow designer'
-    },
-    'configuration-set-detail': {
-      loadingMsg: 'Loading configuration set...',
-      errorMsg: 'Failed to load configuration set'
-    },
-    'workspace-look-and-feel': {
-      loadingMsg: 'Loading Look and Feel...',
-      errorMsg: 'Failed to load Look and Feel',
-      wrapper: 'none',
-      getProps: (route) => ({ workspaceId: route.params.id })
-    },
-    'personal-plan': {
-      loadingMsg: 'Loading Plan My Day...',
-      errorMsg: 'Failed to load Plan My Day',
-      wrapper: 'surface-full'
-    },
-    'logbook': {
-      loadingMsg: 'Loading Knowledge Base...',
-      errorMsg: 'Failed to load Knowledge Base',
-      wrapper: 'surface-full'
-    },
-    'logbook-document': {
-      loadingMsg: 'Loading Document...',
-      errorMsg: 'Failed to load Document',
-      wrapper: 'surface-full',
-      getProps: (route) => ({ documentId: route.params.documentId })
+  function showCreateDropdown() {
+    createModalWorkspaceId = null;
+    const currentWorkspaceId = $currentRoute.params?.id;
+    if (currentWorkspaceId && CREATE_MODAL_WORKSPACE_VIEWS.has($currentRoute.view)) {
+      createModalWorkspaceId = Number.parseInt(currentWorkspaceId, 10);
     }
-  };
-
-  const testViews = new Set([
-    'test-cases',
-    'test-sets',
-    'test-templates',
-    'test-runs',
-    'test-reports',
-    'test-steps',
-    'test-run-detail',
-    'test-template-detail',
-    'test-execution',
-    'test-case-detail',
-    'test-set-detail'
-  ]);
-
-  function resolveRouteConfig(view) {
-    if (!view) {
-      return { key: null, config: null };
-    }
-
-    if (routeConfig[view]) {
-      return { key: view, config: routeConfig[view] };
-    }
-
-    for (const [key, config] of Object.entries(routeConfig)) {
-      if (config.matchViews?.includes(view)) {
-        return { key, config };
-      }
-    }
-
-    return { key: null, config: null };
+    showCreateModal = true;
   }
 
-  // Compute the effective view, replacing item-detail with personal-task-detail for personal workspaces
-  let effectiveView = $derived.by(() => {
-    const view = $currentRoute.view;
+  function showCreateModalFromEvent(detail) {
+    if (detail.type) createModalInitialType = detail.type;
+    createModalSkipNavigate = detail.skipNavigate || false;
+    createModalWorkspaceId = detail.workspaceId
+      ? Number.parseInt(String(detail.workspaceId), 10)
+      : null;
+    showCreateModal = true;
+  }
 
-    // Check if this is an item-detail view and if the workspace is personal
-    if (view === 'item-detail') {
-      const workspaceId = $currentRoute.path?.startsWith('/personal')
-        ? $workspacesStore.personalWorkspace?.id
-        : parseInt($currentRoute.params?.id);
-
-      // Check if this workspace is the personal workspace
-      if ($workspacesStore.personalWorkspace?.id && workspaceId === $workspacesStore.personalWorkspace?.id) {
-        return 'personal-task-detail';
-      }
-    }
-
-    return view;
+  useMainAppLifecycle({
+    onEmailVerificationChange: (show) => showEmailVerificationBanner = show,
+    onShowCommandPalette: () => showCommandPalette = true,
+    onShowCreateModal: showCreateModalFromEvent,
   });
 
-  let showWorkspaceNav = $derived(
-    !$uiStore.reviewFullscreen &&
-    $currentRoute.view !== 'workspaces' &&
-    !!$currentWorkspace &&
-    (isWorkspaceRoute($currentRoute.view) || effectiveView === 'personal-task-detail' || testViews.has($currentRoute.view))
+  const effectiveView = $derived(
+    resolveEffectiveMainAppView($currentRoute, $workspacesStore.personalWorkspace?.id)
   );
-
-  let showCollectionNav = $derived(
+  const showWorkspaceNav = $derived(
+    !$uiStore.reviewFullscreen &&
+      $currentRoute.view !== 'workspaces' &&
+      !!$currentWorkspace &&
+      (isWorkspaceRoute($currentRoute.view) ||
+        effectiveView === 'personal-task-detail' ||
+        MAIN_APP_TEST_VIEWS.has($currentRoute.view))
+  );
+  const showCollectionNav = $derived(
     !$uiStore.reviewFullscreen && GLOBAL_COLLECTION_VIEWS.has($currentRoute.view)
   );
 
-  let routeProps = $derived.by(() => getPropsForRoute(effectiveView));
-
-  onMount(() => {
-    // Initialize activity tracking for adaptive polling
-    activityStore.init();
-
-    // Desktop (Tauri) clients: refresh open views on window/tab focus so
-    // backend changes (CLI edits, other users, agents) appear without a
-    // manual reload. Browser-only no-op.
-    initDesktopFocusRefresh();
-    desktopBridge.init();
-
-    // Start the shared notification poller (feeds tray, toasts, and the
-    // new-notification bus used by item views to refresh instantly).
-    startNotificationPoller();
-
-    // MainApp only renders after authentication. Start the small navigation /
-    // permission critical path together with every optional capability probe;
-    // optional work must not delay the first useful route.
-    const user = authStore.currentUser;
-    const userId = authStore.currentUser?.id;
-    const criticalTasks = [
-      () => workspacesStore.load(),
-      () => permissionStore.loadAllPermissions(user),
-    ];
-    if (userId) {
-      criticalTasks.push(
-        () => permissionStore.loadUserPermissions(userId),
-        () => workspacePermissions.loadPermissions(userId),
-      );
-    }
-
-    const deferredTasks = [
-      () => workspacesStore.loadPersonalWorkspace(),
-      async () => {
-        try {
-          const bootstrap = await api.shellBootstrap.get();
-          hydrateAuthenticatedShellUI(bootstrap);
-        } catch (err) {
-          capabilitiesStore.failHydration();
-          console.warn('Failed to load shell capabilities:', err);
-        }
-      },
-      async () => {
-        if (ssoStore.checkForEmailVerificationPending()) {
-          showEmailVerificationBanner = true;
-          return;
-        }
-        try {
-          const status = await ssoStore.getVerificationStatus();
-          showEmailVerificationBanner = Boolean(status.configured && !status.email_verified);
-        } catch (err) {
-          console.warn('Failed to check email verification status:', err);
-        }
-      },
-    ];
-
-    void runAuthenticatedShellBootstrap({
-      userId,
-      criticalTasks,
-      deferredTasks,
-      onMeasured: (metrics) => {
-        window.dispatchEvent(new CustomEvent('windshift:auth-shell-bootstrap', { detail: metrics }));
-      },
-    });
-
-    return () => {
-      stopNotificationPoller();
-      homepageStore.reset();
-      resetAuthenticatedShellState();
-    };
-  });
-
-  // Double-space handler for command palette (manual — not a simple hotkey)
-  useEventListener(() => document, 'keydown', (e) => {
-    if (e.code !== 'Space') return;
-
-    const target = /** @type {HTMLElement} */ (e.target);
-    const isInInputField = target.tagName === 'INPUT' ||
-                          target.tagName === 'TEXTAREA' ||
-                          target.contentEditable === 'true' ||
-                          target.closest('[contenteditable="true"]');
-    if (isInInputField) return;
-
-    const now = Date.now();
-    if (now - lastSpaceTime < DOUBLE_SPACE_THRESHOLD) {
-      e.preventDefault();
-      showCommandPalette = true;
-    } else {
-      e.preventDefault();
-    }
-    lastSpaceTime = now;
-  });
-
-  // Listen for create modal events and workspace refresh from other components
-  onMount(() => {
-    function handleShowCreateModal(event) {
-      const detail = event.detail || {};
-
-      if (detail.type) {
-        createModalInitialType = detail.type;
-      }
-      createModalSkipNavigate = detail.skipNavigate || false;
-      createModalWorkspaceId = detail.workspaceId
-        ? Number.parseInt(String(detail.workspaceId), 10)
-        : null;
-
-      showCreateModal = true;
-    }
-
-    window.addEventListener('show-create-modal', handleShowCreateModal);
-
-    function handleRefreshWorkspaces() {
-      workspacesStore.reload();
-    }
-
-    function handleRefreshWorkspaceData() {
-      workspaceDataStore.refresh();
-    }
-
-    function handleRefreshWorkItems() {
-      homepageStore.invalidateSnapshot();
-    }
-
-    window.addEventListener(ADMIN_UI_MUTATION_EVENT, scheduleAdminUIRefresh);
-    window.addEventListener('refresh-workspaces', handleRefreshWorkspaces);
-    window.addEventListener('refresh-workspace-data', handleRefreshWorkspaceData);
-    window.addEventListener('refresh-work-items', handleRefreshWorkItems);
-
-    return () => {
-      window.removeEventListener('show-create-modal', handleShowCreateModal);
-      window.removeEventListener(ADMIN_UI_MUTATION_EVENT, scheduleAdminUIRefresh);
-      window.removeEventListener('refresh-workspaces', handleRefreshWorkspaces);
-      window.removeEventListener('refresh-workspace-data', handleRefreshWorkspaceData);
-      window.removeEventListener('refresh-work-items', handleRefreshWorkItems);
-      if (adminUIRefreshTimer) clearTimeout(adminUIRefreshTimer);
-    };
-  });
-  // Load current workspace when route changes (only for workspace routes).
-  // workspaceDataStore owns the request; currentWorkspace is hydrated from the
-  // same response so the shell does not issue an identical workspace GET.
   $effect(() => {
-    // Handle personal workspace routes
-    if ($currentRoute.path?.startsWith('/personal') && ($currentRoute.view?.startsWith('workspace-') || $currentRoute.view === 'personal-workspace' || $currentRoute.view === 'personal-plan' || $currentRoute.view === 'item-detail')) {
-      const personalWorkspaceId = $workspacesStore.personalWorkspace?.id;
-      if (personalWorkspaceId) {
-        void hydrateCurrentWorkspaceFromSharedData(personalWorkspaceId);
-      } else {
-        // Personal workspace not loaded yet - trigger loading
-        // The effect will re-run when personalWorkspace is set in the store
-        workspacesStore.loadPersonalWorkspace();
-      }
-    }
-    // Handle regular workspace routes
-    else if ($currentRoute.params?.id && /^\d+$/.test(String($currentRoute.params.id)) && ($currentRoute.view?.startsWith('workspace-') || $currentRoute.view === 'workspace' || $currentRoute.view === 'item-detail' || $currentRoute.view === 'item' || testViews.has($currentRoute.view))) {
-      void hydrateCurrentWorkspaceFromSharedData($currentRoute.params.id);
-    }
-    // Handle global collection views (no workspace)
-    else if (GLOBAL_COLLECTION_VIEWS.has($currentRoute.view)) {
+    const route = $currentRoute;
+    const context = resolveMainAppWorkspaceContext(
+      route,
+      $workspacesStore.personalWorkspace?.id
+    );
+
+    if (context.kind === 'workspace') {
+      void hydrateCurrentWorkspaceFromSharedData(context.workspaceId);
+    } else if (context.kind === 'personal-pending') {
+      void workspacesStore.loadPersonalWorkspace();
+    } else if (context.kind === 'global-collection') {
       if ($currentWorkspace) currentWorkspace.clear();
       workspaceDataStore.initializeGlobal();
       clearWorkspaceGradient();
@@ -890,521 +205,138 @@
     }
   });
 
-  // Collection store is self-activating via route subscription in constructor — no need to manually activate
-
-  // Redirect from workspace-detail to the configured default view. The
-  // collection-scoped base URL maps to this same view, so carry the collection
-  // through — dropping it silently lands on the workspace board, which reads
-  // the workspace board configuration instead of the collection's.
   $effect(() => {
-    if ($currentRoute.view === 'workspace-detail' && $currentWorkspace) {
-      const wsId = $currentRoute.params?.id;
-      if (wsId) {
-        const defaultView = $currentWorkspace.default_view || 'board';
-        const collectionId = $currentRoute.params?.collectionId;
-        const base = collectionId
-          ? `/workspaces/${wsId}/collections/${collectionId}`
-          : `/workspaces/${wsId}`;
-        navigate(`${base}/${defaultView}`, { replace: true });
-      }
-    }
-  });
-
-  // Load terminal panel when terminal becomes visible
-  $effect(() => {
-    if (terminalState.visible && !TerminalPanelComponent) {
-      loadTerminalPanel();
-    }
+    const redirect = getMainAppWorkspaceRedirect($currentRoute, $currentWorkspace);
+    if (redirect) navigate(redirect, { replace: true });
   });
 
   $effect(() => {
-    if (desktopBridge.modal) {
-      loadDesktopModal(desktopBridge.modal);
-    }
+    if (terminalState.visible && !TerminalPanelComponent) void loadTerminalPanel();
   });
-
-  // Single effect to load components based on current route
-  $effect(() => {
-    const view = effectiveView;
-
-    // Load component for current route view
-    if (view) {
-      const { key } = resolveRouteConfig(view);
-      if (key) {
-        loadComponentForRoute(key);
-      }
-    }
-
-    // Load command palette when opened
-    if (showCommandPalette) {
-      loadComponentForRoute('command-palette');
-    }
-
-    // Load create modal when opened
-    if (showCreateModal) {
-      loadComponentForRoute('create-modal');
-    }
-  });
-
-
-
-  function showCreateDropdown() {
-    createModalWorkspaceId = null;
-
-    // Pre-select current workspace if we're in a workspace context
-    const currentWorkspaceId = $currentRoute.params?.id;
-    if (currentWorkspaceId && ['workspace-detail', 'workspace-calendar', 'workspace-reviews', 'workspace-settings', 'workspace-settings-general', 'workspace-settings-categories', 'workspace-settings-members', 'workspace-settings-configuration', 'workspace-settings-source-control', 'workspace-settings-coding-agents', 'workspace-settings-issue-sync', 'workspace-settings-templates', 'workspace-settings-danger', 'workspace-look-and-feel', 'workspace-board', 'workspace-backlog', 'workspace-list', 'workspace-tree', 'workspace-map', 'workspace-roadmap', 'workspace-actions', 'item-detail'].includes($currentRoute.view)) {
-      createModalWorkspaceId = Number.parseInt(currentWorkspaceId, 10);
-    }
-    showCreateModal = true;
-  }
-
-  // Generic lazy loader function for all routes
-  async function loadComponentForRoute(view) {
-    return lazyComponents.load(view);
-  }
-
-  function retryComponentForRoute(view) {
-    return lazyComponents.retry(view);
-  }
-
-  // Helper to get component for current view (supports matchViews)
-  function getComponentForView(view) {
-    // Direct match
-    if (lazyComponents.getComponent(view)) {
-      return lazyComponents.getComponent(view);
-    }
-
-    const { key } = resolveRouteConfig(view);
-    if (key && lazyComponents.getComponent(key)) {
-      return lazyComponents.getComponent(key);
-    }
-
-    return null;
-  }
-
-  // Helper to check if component is loading
-  function isComponentLoading(view) {
-    if (lazyComponents.isLoading(view)) return true;
-
-    const { key } = resolveRouteConfig(view);
-    if (key && lazyComponents.isLoading(key)) {
-      return true;
-    }
-
-    return false;
-  }
-
-  function getComponentLoadError(view) {
-    if (lazyComponents.getError(view)) return lazyComponents.getError(view);
-
-    const { key } = resolveRouteConfig(view);
-    if (key) return lazyComponents.getError(key);
-
-    return null;
-  }
-
-  // Get props for current route's component
-  function getPropsForRoute(view) {
-    const { config } = resolveRouteConfig(view);
-    if (!config || !config.getProps) return {};
-    return config.getProps($currentRoute);
-  }
-
-  // Check if a route requires wrapper styling
-  function getWrapperClass(view) {
-    const { config } = resolveRouteConfig(view);
-    return config?.wrapper || null;
-  }
 </script>
 
-{#snippet loadingState(message)}
-  <div class="flex items-center justify-center h-full">
-    <div class="text-center">
-      <Spinner class="mx-auto mb-4" />
-      <p class="text-gray-600">{message}</p>
-    </div>
-  </div>
-{/snippet}
-
-{#snippet errorState(message, retryFn)}
-  <div class="flex items-center justify-center h-full">
-    <div class="text-center">
-      <p class="text-red-600">{message}</p>
-      {#if retryFn}
-        <Button variant="primary" onclick={retryFn} class="mt-4">
-          {t('nav.retry')}
-        </Button>
-      {/if}
-    </div>
-  </div>
-{/snippet}
-
-{#snippet lazyLoadedComponent(view, props)}
-  {@const component = getComponentForView(view)}
-  {@const loading = isComponentLoading(view)}
-  {@const loadError = getComponentLoadError(view)}
-  {@const routeEntry = resolveRouteConfig(view)}
-  {@const config = routeEntry.config}
-  {@const loaderKey = routeEntry.key || view}
-
-  {#if loading}
-    {@render loadingState(config?.loadingMsg || 'Loading...')}
-  {:else if component}
-    {@const LazyComponent = component}
-    <LazyComponent {...props} />
-  {:else if loadError}
-    {@render errorState(config?.errorMsg || 'Failed to load component', () => retryComponentForRoute(loaderKey))}
-  {:else}
-    {@render loadingState(config?.loadingMsg || 'Loading...')}
-  {/if}
-{/snippet}
-
-<!-- Main Internal App - Rendered only when user is authenticated -->
 <div class="min-h-screen flex flex-col" style="background-color: var(--ds-surface);">
-  <!-- Email Verification Banner -->
   <EmailVerificationBanner
     show={showEmailVerificationBanner}
     ondismiss={() => showEmailVerificationBanner = false}
   />
 
-  <!-- Vertical Left Sidebar Navigation -->
   {#if !$uiStore.reviewFullscreen}
     <MainSidebar
       onShowCommandPalette={() => showCommandPalette = true}
       onShowCreateModal={showCreateDropdown}
-      onShowChatPanel={() => { showChatPanel = true; loadComponentForRoute('chat-panel'); }}
+      onShowChatPanel={() => showChatPanel = true}
       onToggleTerminal={toggleTerminal}
     />
   {/if}
 
-  <!-- Hidden hotkey buttons for global shortcuts -->
   <Button class="sr-only" onclick={() => showCommandPalette = true} hotkeyConfig={{ key: toHotkeyString('global', 'commandPalette') }}>Command Palette</Button>
   <Button class="sr-only" onclick={showCreateDropdown} hotkeyConfig={{ key: toHotkeyString('global', 'create') }}>Create</Button>
   {#if aiStore.chatAvailable}
-    <Button class="sr-only" onclick={() => { showChatPanel = !showChatPanel; loadComponentForRoute('chat-panel'); }} hotkeyConfig={{ key: toHotkeyString('global', 'aiChat') }}>AI Chat</Button>
+    <Button class="sr-only" onclick={() => showChatPanel = !showChatPanel} hotkeyConfig={{ key: toHotkeyString('global', 'aiChat') }}>AI Chat</Button>
   {/if}
   <Button class="sr-only" onclick={toggleTerminal} hotkeyConfig={{ key: 'Mod+`' }}>Toggle Terminal</Button>
 
-    <!-- Main Content Area with Sidebar Layout -->
-    <div
-      class="authenticated-content flex flex-1 transition-[margin] duration-200 ease-out"
-      class:has-mobile-context-nav={showWorkspaceNav}
-      style={!$uiStore.reviewFullscreen ? `margin-left: ${$uiStore.navExpanded ? '200px' : '64px'}` : ''}
-    >
-      <!-- Left Sidebar for Workspace/Admin Navigation -->
-      {#if showWorkspaceNav}
-        <Button
-          class="mobile-workspace-nav-trigger"
-          variant="default"
-          size="small"
-          icon={Menu}
-          title={mobileWorkspaceNavOpen ? 'Close workspace navigation' : 'Open workspace navigation'}
-          dataTestid="mobile-workspace-nav-trigger"
-          onclick={() => mobileWorkspaceNavOpen = !mobileWorkspaceNavOpen}
-        >
-          Workspace
-        </Button>
-        {#if mobileWorkspaceNavOpen}
-          <button
-            type="button"
-            class="mobile-workspace-nav-backdrop"
-            aria-label="Close workspace navigation"
-            data-testid="mobile-workspace-nav-backdrop"
-            onclick={() => mobileWorkspaceNavOpen = false}
-          ></button>
-        {/if}
-        <div
-          class="workspace-context-nav"
-          class:mobile-open={mobileWorkspaceNavOpen}
-          out:slide={{ duration: 200, axis: 'x' }}
-        >
-          <WorkspaceNavigation workspaceId={$currentRoute.path?.startsWith('/personal') ? $workspacesStore.personalWorkspace?.id : $currentRoute.params.id} />
-        </div>
-      {:else if showCollectionNav}
-        <div out:slide={{ duration: 200, axis: 'x' }}>
-          <CollectionNavigation collectionId={$currentRoute.params.id} />
-        </div>
+  <div
+    class="authenticated-content flex flex-1 transition-[margin] duration-200 ease-out"
+    class:has-mobile-context-nav={showWorkspaceNav}
+    style={!$uiStore.reviewFullscreen ? `margin-left: ${$uiStore.navExpanded ? '200px' : '64px'}` : ''}
+  >
+    {#if showWorkspaceNav}
+      <Button
+        class="mobile-workspace-nav-trigger"
+        variant="default"
+        size="small"
+        icon={Menu}
+        title={mobileWorkspaceNavOpen ? 'Close workspace navigation' : 'Open workspace navigation'}
+        dataTestid="mobile-workspace-nav-trigger"
+        onclick={() => mobileWorkspaceNavOpen = !mobileWorkspaceNavOpen}
+      >
+        Workspace
+      </Button>
+      {#if mobileWorkspaceNavOpen}
+        <button
+          type="button"
+          class="mobile-workspace-nav-backdrop"
+          aria-label="Close workspace navigation"
+          data-testid="mobile-workspace-nav-backdrop"
+          onclick={() => mobileWorkspaceNavOpen = false}
+        ></button>
       {/if}
-
-      <!-- Main Content Column (with optional terminal split) -->
-      <div class="flex-1 flex min-w-0 main-split-container">
-        <!-- Left Pane: Main Content -->
-        <div
-          class="flex flex-col min-w-0"
-          style={terminalState.visible ? `width: ${terminalState.splitPercent}%; flex-shrink: 0;` : 'flex: 1;'}
-        >
-        <!-- Main Content -->
-        <main class="flex-1">
-    {#if true}
-      {@const view = effectiveView}
-      {@const wrapper = getWrapperClass(view)}
-      {@const routeEntry = resolveRouteConfig(view)}
-      {@const hasLazyRoute = !!routeEntry.config}
-
-      {#if view === 'workspaces'}
-      <Workspaces showAdminHeader={false} />
-
-    {:else if ['workspace-settings', 'workspace-settings-general', 'workspace-settings-categories', 'workspace-settings-members', 'workspace-settings-configuration', 'workspace-settings-source-control', 'workspace-settings-coding-agents', 'workspace-settings-issue-sync', 'workspace-settings-recurrence', 'workspace-settings-templates', 'workspace-settings-danger'].includes(view)}
-      <div class="p-6" style="background-color: var(--ds-surface);">
-        <WorkspaceSettings
-          workspaceId={$currentRoute.params.id}
-          activeTab={
-            view === 'workspace-settings-categories' ? 'categories' :
-            view === 'workspace-settings-members' ? 'members' :
-            view === 'workspace-settings-configuration' ? 'configuration' :
-            view === 'workspace-settings-source-control' ? 'source-control' :
-            view === 'workspace-settings-coding-agents' ? 'coding-agents' :
-            view === 'workspace-settings-issue-sync' ? 'issue-sync' :
-            view === 'workspace-settings-recurrence' ? 'recurrence' :
-            view === 'workspace-settings-templates' ? 'templates' :
-            view === 'workspace-settings-danger' ? 'danger' :
-            'general'
-          }
+      <div
+        class="workspace-context-nav"
+        class:mobile-open={mobileWorkspaceNavOpen}
+        out:slide={{ duration: 200, axis: 'x' }}
+      >
+        <WorkspaceNavigation
+          workspaceId={$currentRoute.path?.startsWith('/personal')
+            ? $workspacesStore.personalWorkspace?.id
+            : $currentRoute.params.id}
         />
       </div>
-
-    {:else if view === 'collections-list'}
-      <CollectionsList />
-    {:else if view === 'collections-edit'}
-      <Collections collectionId={$currentRoute.params.id} />
-
-    {:else if view === 'channels'}
-      <div style="background-color: var(--ds-surface);">
-        <Channels />
+    {:else if showCollectionNav}
+      <div out:slide={{ duration: 200, axis: 'x' }}>
+        <CollectionNavigation collectionId={$currentRoute.params.id} />
       </div>
-    {:else if view === 'hub' || view === 'hub-inbox'}
-      <div style="background-color: var(--ds-surface);">
-        <Hub />
-      </div>
-    {:else if view === 'organizations' || view === 'organization-contact-detail'}
-      <Customers />
-
-    {:else if view === 'teams-list'}
-      <div class="p-6" style="background-color: var(--ds-surface);">
-        <TeamsList />
-      </div>
-    {:else if view === 'team-detail'}
-      <div class="p-6" style="background-color: var(--ds-surface);">
-        <TeamDetail teamId={$currentRoute.params.id} section={$currentRoute.params.section || 'overview'} />
-      </div>
-
-    {:else if view === 'notifications'}
-      <NotificationsPage />
-    {:else if view === 'approvals-inbox'}
-      <ApprovalsInbox />
-    {:else if view === 'search'}
-      <SearchPage />
-
-    {:else if view === 'profile'}
-      <div class="p-6" style="background-color: var(--ds-surface);">
-        <UserProfile />
-      </div>
-    {:else if view === 'security'}
-      <div class="p-6" style="background-color: var(--ds-surface);">
-        <Security />
-      </div>
-
-    {:else if view === 'about'}
-      <About />
-    {:else if view === 'api-docs'}
-      <ApiDocs />
-    {:else if view === 'cli-authorize'}
-      <CliAuthorize />
-    {:else if view === 'oauth-authorize'}
-      <OAuthAuthorize />
-    {:else if view === '404'}
-      <div class="p-6" style="background-color: var(--ds-surface);">
-        <NotFound />
-      </div>
-
-    {:else if view === 'admin'}
-      {#if $currentRoute.path.startsWith('/admin/channels')}
-        {@render lazyLoadedComponent(view, routeProps)}
-      {:else}
-        <PermissionGuard requireSystemAdmin={true}>
-          {#snippet children()}
-            {@render lazyLoadedComponent(view, routeProps)}
-          {/snippet}
-          {#snippet fallback(requiredPermissionDisplay)}
-            <UnauthorizedAccess
-              message="You need system administrator privileges to access the administration panel."
-              requiredPermission={requiredPermissionDisplay}
-            />
-          {/snippet}
-        </PermissionGuard>
-      {/if}
-
-    {:else if view === 'workspace-actions'}
-      <div class="h-full" style="background-color: var(--ds-surface); height: calc(100vh - 56px);">
-        {@render lazyLoadedComponent(view, routeProps)}
-      </div>
-
-    {:else if hasLazyRoute}
-      {#if wrapper === 'surface-full'}
-        <div style="background-color: var(--ds-surface);">
-          {@render lazyLoadedComponent(view, routeProps)}
-        </div>
-      {:else if wrapper === 'surface-padded'}
-        <div class="p-6" style="background-color: var(--ds-surface);">
-          {@render lazyLoadedComponent(view, routeProps)}
-        </div>
-      {:else if wrapper === 'surface-admin'}
-        <div class="px-16 py-12 flex-1 overflow-y-auto" style="background-color: var(--ds-surface);">
-          {@render lazyLoadedComponent(view, routeProps)}
-        </div>
-      {:else}
-        {@render lazyLoadedComponent(view, routeProps)}
-      {/if}
-
-      {:else}
-        <Workspaces showAdminHeader={false} />
-      {/if}
     {/if}
-      </main>
+
+    <div class="flex-1 flex min-w-0 main-split-container">
+      <div
+        class="flex flex-col min-w-0"
+        style={terminalState.visible
+          ? `width: ${terminalState.splitPercent}%; flex-shrink: 0;`
+          : 'flex: 1;'}
+      >
+        <main class="flex-1">
+          <MainRouteContent view={effectiveView} route={$currentRoute} {lazyComponents} />
+        </main>
       </div>
 
-        {#if terminalState.visible}
-          <!-- Resize Handle -->
-          <!-- svelte-ignore a11y_no_static_element_interactions -->
-          <div
-            class="terminal-resize-handle w-1 cursor-col-resize hover:bg-blue-500/40 active:bg-blue-500/60 transition-colors flex-shrink-0"
-            style="background-color: var(--ds-border);"
-            onmousedown={handleTerminalResizeStart}
-          ></div>
-
-          <!-- Right Pane: Terminal -->
-          <div
-            class="flex flex-col min-w-0"
-            style="width: {100 - terminalState.splitPercent}%; flex-shrink: 0;"
-          >
-            {#if TerminalPanelComponent}
-              <TerminalPanelComponent />
-            {:else if terminalLoading}
-              <div class="flex items-center justify-center h-full" style="background-color: #1a1b26;">
-                <Spinner />
-              </div>
-            {/if}
-          </div>
-        {/if}
-      </div>
+      {#if terminalState.visible}
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <div
+          class="terminal-resize-handle w-1 cursor-col-resize hover:bg-blue-500/40 active:bg-blue-500/60 transition-colors flex-shrink-0"
+          style="background-color: var(--ds-border);"
+          onmousedown={handleTerminalResizeStart}
+        ></div>
+        <div
+          class="flex flex-col min-w-0"
+          style="width: {100 - terminalState.splitPercent}%; flex-shrink: 0;"
+        >
+          {#if TerminalPanelComponent}
+            <TerminalPanelComponent />
+          {:else if terminalLoading}
+            <div class="flex items-center justify-center h-full" style="background-color: #1a1b26;">
+              <Spinner />
+            </div>
+          {/if}
+        </div>
+      {/if}
     </div>
-    
-    <!-- Footer with proper sidebar margin -->
-    <footer
-      class="authenticated-footer transition-transform duration-200 ease-out {!$uiStore.reviewFullscreen ? 'ml-16' : ''}"
-      style={!$uiStore.reviewFullscreen ? `transform: translateX(${$uiStore.navExpanded ? '136px' : '0px'})` : ''}
-    >
-      <Footer />
-    </footer>
+  </div>
+
+  <footer
+    class="authenticated-footer transition-transform duration-200 ease-out {!$uiStore.reviewFullscreen ? 'ml-16' : ''}"
+    style={!$uiStore.reviewFullscreen
+      ? `transform: translateX(${$uiStore.navExpanded ? '136px' : '0px'})`
+      : ''}
+  >
+    <Footer />
+  </footer>
 </div>
 
-
-<!-- Command Palette -->
-{#if true}
-  {@const commandPaletteComponent = getComponentForView('command-palette')}
-  {@const commandPaletteLoading = isComponentLoading('command-palette')}
-  {@const commandPaletteError = getComponentLoadError('command-palette')}
-
-  {#if commandPaletteLoading}
-    <ModalBackdrop show={true} opacity={0.4} blur={8} extraFilter="saturate(120%)" zIndex={60} align="top" paddingTop="pt-[20vh]" closeOnClick={false} closeOnEscape={false} transition={false}>
-      <div class="rounded-xl p-6" style="background-color: var(--ds-surface-raised); color: var(--ds-text-subtle);">
-        <Spinner class="mx-auto mb-4" />
-        <p>{t('nav.loadingSearch')}</p>
-      </div>
-    </ModalBackdrop>
-  {:else if commandPaletteComponent && showCommandPalette}
-    {@const CommandPalette = commandPaletteComponent}
-    <CommandPalette
-      bind:isOpen={showCommandPalette}
-      onclose={() => showCommandPalette = false}
-    />
-  {:else if commandPaletteError && showCommandPalette}
-    <!-- shortcut-guard-exempt: retrying a failed lazy import is a recovery action, not a form submission. -->
-    <ModalBackdrop show={true} opacity={0.4} zIndex={60} closeOnClick={false} onclose={() => showCommandPalette = false}>
-      <div class="rounded-xl p-6 text-center" role="alert" style="background-color: var(--ds-surface-raised); color: var(--ds-text);">
-        <p class="font-semibold">Failed to load Search</p>
-        <p class="mt-1 text-sm" style="color: var(--ds-text-subtle);">Check your connection, then try again.</p>
-        <div class="mt-4 flex justify-center gap-2">
-          <Button variant="secondary" onclick={() => showCommandPalette = false}>{t('common.close')}</Button>
-          <Button variant="primary" onclick={() => retryComponentForRoute('command-palette')}>{t('nav.retry')}</Button>
-        </div>
-      </div>
-    </ModalBackdrop>
-  {/if}
-{/if}
-
-<!-- Create Modal -->
-{#if true}
-  {@const createModalComponent = getComponentForView('create-modal')}
-  {@const createModalLoading = isComponentLoading('create-modal')}
-  {@const createModalError = getComponentLoadError('create-modal')}
-
-  {#if createModalLoading}
-    <ModalBackdrop show={true} opacity={0.4} closeOnClick={false} closeOnEscape={false} transition={false}>
-      <div class="rounded-xl p-6" style="background-color: var(--ds-surface-raised); color: var(--ds-text-subtle);">
-        <Spinner class="mx-auto mb-4" />
-        <p>{t('nav.loadingCreateForm')}</p>
-      </div>
-    </ModalBackdrop>
-  {:else if createModalComponent && showCreateModal}
-    {@const CreateModal = createModalComponent}
-    <CreateModal
-      bind:isOpen={showCreateModal}
-      initialType={createModalInitialType}
-      initialWorkspaceId={createModalWorkspaceId}
-      skipNavigate={createModalSkipNavigate}
-      onclose={closeCreateModal}
-    />
-  {:else if createModalError && showCreateModal}
-    <!-- shortcut-guard-exempt: retrying a failed lazy import is a recovery action, not a form submission. -->
-    <ModalBackdrop show={true} opacity={0.4} closeOnClick={false} onclose={closeCreateModal}>
-      <div class="rounded-xl p-6 text-center" role="alert" data-testid="create-modal-load-error" style="background-color: var(--ds-surface-raised); color: var(--ds-text);">
-        <p class="font-semibold">Failed to load Create Form</p>
-        <p class="mt-1 text-sm" style="color: var(--ds-text-subtle);">Check your connection, then try again.</p>
-        <div class="mt-4 flex justify-center gap-2">
-          <Button variant="secondary" onclick={closeCreateModal}>{t('common.close')}</Button>
-          <Button variant="primary" onclick={() => retryComponentForRoute('create-modal')}>{t('nav.retry')}</Button>
-        </div>
-      </div>
-    </ModalBackdrop>
-  {/if}
-{/if}
-
-<!-- Global Confirmation Dialog -->
-<GlobalConfirmDialog />
-
-{#if desktopBridge.modal === 'pomodoro-settings' && PomodoroSettingsModalComponent}
-  <PomodoroSettingsModalComponent
-    show={true}
-    onclose={() => desktopBridge.close()}
-  />
-{:else if desktopBridge.modal === 'about' && AboutModalComponent}
-  <AboutModalComponent
-    show={true}
-    onclose={() => desktopBridge.close()}
-  />
-{/if}
-
-<!-- Floating Timer -->
-<FloatingTimer />
-
-<!-- AI Chat Panel -->
-{#if aiStore.chatAvailable && showChatPanel}
-  {@const ChatPanelComponent = getComponentForView('chat-panel')}
-  {#if ChatPanelComponent}
-    <ChatPanelComponent
-      bind:isOpen={showChatPanel}
-      onclose={() => { showChatPanel = false; }}
-    />
-  {/if}
-{/if}
-
-<!-- Toast Container -->
-<ToastContainer />
+<MainAppOverlays
+  {lazyComponents}
+  bind:showCommandPalette
+  bind:showCreateModal
+  bind:showChatPanel
+  {createModalInitialType}
+  {createModalWorkspaceId}
+  {createModalSkipNavigate}
+  onclosecreate={closeCreateModal}
+/>
 
 <style>
-  /* Global CSS custom properties for theming - uses design tokens */
   :global(html) {
     --nav-bg-color: var(--ds-surface-raised);
     --nav-text-color: var(--ds-text);
@@ -1462,24 +394,20 @@
     }
   }
 
-  /* Themed navigation styles */
   :global(.themed-nav) {
     background-color: var(--nav-bg-color);
     color: var(--nav-text-color);
   }
 
-  /* Ensure child elements inherit the theme colors */
   :global(.themed-nav *) {
     color: inherit;
   }
 
-  /* Override any specific text colors for navigation elements */
   :global(.themed-nav a),
   :global(.themed-nav button) {
     color: var(--nav-text-color);
   }
 
-  /* Theme-aware navigation button classes with enhanced animations */
   :global(.themed-nav .nav-button) {
     color: var(--nav-text-color);
     position: relative;
@@ -1488,17 +416,12 @@
       box-shadow var(--duration-normal, 200ms) var(--ease-smooth, ease);
   }
 
-  /* Subtle glow effect on hover */
   :global(.themed-nav .nav-button::before) {
     content: '';
     position: absolute;
     inset: -2px;
     border-radius: 8px;
-    background: radial-gradient(
-      circle at center,
-      var(--ds-interactive) 0%,
-      transparent 70%
-    );
+    background: radial-gradient(circle at center, var(--ds-interactive) 0%, transparent 70%);
     opacity: 0;
     transition: opacity var(--duration-normal, 200ms) var(--ease-smooth, ease);
     pointer-events: none;
@@ -1517,7 +440,6 @@
     background-color: color-mix(in srgb, var(--ds-interactive) 8%, transparent);
   }
 
-  /* Exception: Primary buttons should keep their original colors and hover behavior */
   :global(.themed-nav .bg-primary) {
     color: var(--ds-text-inverse) !important;
     background-color: var(--ds-interactive) !important;
@@ -1537,19 +459,18 @@
     transform: scale(0.95);
   }
 
-  /* Reduced motion support */
   @media (prefers-reduced-motion: reduce) {
     :global(.themed-nav .nav-button),
     :global(.themed-nav .bg-primary) {
       transition: none;
     }
+
     :global(.themed-nav .bg-primary:hover),
     :global(.themed-nav .bg-primary:active) {
       transform: none;
     }
   }
 
-  /* Terminal resize handle */
   .terminal-resize-handle {
     position: relative;
     z-index: 10;

--- a/frontend/src/lib/pages/MainAppOverlays.svelte
+++ b/frontend/src/lib/pages/MainAppOverlays.svelte
@@ -1,0 +1,148 @@
+<script>
+  import Button from '../components/Button.svelte';
+  import ModalBackdrop from '../components/ModalBackdrop.svelte';
+  import Spinner from '../components/Spinner.svelte';
+  import { desktopBridge } from '../desktop/bridge.svelte.js';
+  import GlobalConfirmDialog from '../dialogs/GlobalConfirmDialog.svelte';
+  import ToastContainer from '../features/notifications/ToastContainer.svelte';
+  import FloatingTimer from '../features/time/FloatingTimer.svelte';
+  import { aiStore } from '../stores/aiStore.svelte.js';
+  import { t } from '../stores/i18n.svelte.js';
+  import { getMainAppLazyState } from './mainAppRoutes.js';
+
+  let {
+    lazyComponents,
+    showCommandPalette = $bindable(false),
+    showCreateModal = $bindable(false),
+    showChatPanel = $bindable(false),
+    createModalInitialType = 'work-item',
+    createModalWorkspaceId = null,
+    createModalSkipNavigate = false,
+    onclosecreate,
+  } = $props();
+
+  let PomodoroSettingsModalComponent = $state(null);
+  let AboutModalComponent = $state(null);
+  let desktopModalLoading = $state(false);
+
+  const commandPaletteState = $derived.by(() =>
+    getMainAppLazyState(lazyComponents, 'command-palette')
+  );
+  const createModalState = $derived.by(() =>
+    getMainAppLazyState(lazyComponents, 'create-modal')
+  );
+  const chatPanelState = $derived.by(() => getMainAppLazyState(lazyComponents, 'chat-panel'));
+
+  async function loadDesktopModal(modal) {
+    if (desktopModalLoading) return;
+    if (modal === 'pomodoro-settings' && PomodoroSettingsModalComponent) return;
+    if (modal === 'about' && AboutModalComponent) return;
+
+    desktopModalLoading = true;
+    try {
+      if (modal === 'pomodoro-settings') {
+        const module = await import('../dialogs/PomodoroSettingsModal.svelte');
+        PomodoroSettingsModalComponent = module.default;
+      } else if (modal === 'about') {
+        const module = await import('../dialogs/AboutModal.svelte');
+        AboutModalComponent = module.default;
+      }
+    } catch (error) {
+      console.error('Failed to load desktop modal:', error);
+    } finally {
+      desktopModalLoading = false;
+    }
+  }
+
+  $effect(() => {
+    if (showCommandPalette) void lazyComponents.load('command-palette');
+    if (showCreateModal) void lazyComponents.load('create-modal');
+    if (showChatPanel) void lazyComponents.load('chat-panel');
+  });
+
+  $effect(() => {
+    if (desktopBridge.modal) void loadDesktopModal(desktopBridge.modal);
+  });
+</script>
+
+{#if commandPaletteState.loading}
+  <ModalBackdrop
+    show={true}
+    opacity={0.4}
+    blur={8}
+    extraFilter="saturate(120%)"
+    zIndex={60}
+    align="top"
+    paddingTop="pt-[20vh]"
+    closeOnClick={false}
+    closeOnEscape={false}
+    transition={false}
+  >
+    <div class="rounded-xl p-6" style="background-color: var(--ds-surface-raised); color: var(--ds-text-subtle);">
+      <Spinner class="mx-auto mb-4" />
+      <p>{t('nav.loadingSearch')}</p>
+    </div>
+  </ModalBackdrop>
+{:else if commandPaletteState.component && showCommandPalette}
+  {@const CommandPalette = commandPaletteState.component}
+  <CommandPalette bind:isOpen={showCommandPalette} onclose={() => showCommandPalette = false} />
+{:else if commandPaletteState.error && showCommandPalette}
+  <!-- shortcut-guard-exempt: retrying a failed lazy import is a recovery action, not a form submission. -->
+  <ModalBackdrop show={true} opacity={0.4} zIndex={60} closeOnClick={false} onclose={() => showCommandPalette = false}>
+    <div class="rounded-xl p-6 text-center" role="alert" style="background-color: var(--ds-surface-raised); color: var(--ds-text);">
+      <p class="font-semibold">Failed to load Search</p>
+      <p class="mt-1 text-sm" style="color: var(--ds-text-subtle);">Check your connection, then try again.</p>
+      <div class="mt-4 flex justify-center gap-2">
+        <Button variant="secondary" onclick={() => showCommandPalette = false}>{t('common.close')}</Button>
+        <Button variant="primary" onclick={() => lazyComponents.retry('command-palette')}>{t('nav.retry')}</Button>
+      </div>
+    </div>
+  </ModalBackdrop>
+{/if}
+
+{#if createModalState.loading}
+  <ModalBackdrop show={true} opacity={0.4} closeOnClick={false} closeOnEscape={false} transition={false}>
+    <div class="rounded-xl p-6" style="background-color: var(--ds-surface-raised); color: var(--ds-text-subtle);">
+      <Spinner class="mx-auto mb-4" />
+      <p>{t('nav.loadingCreateForm')}</p>
+    </div>
+  </ModalBackdrop>
+{:else if createModalState.component && showCreateModal}
+  {@const CreateModal = createModalState.component}
+  <CreateModal
+    bind:isOpen={showCreateModal}
+    initialType={createModalInitialType}
+    initialWorkspaceId={createModalWorkspaceId}
+    skipNavigate={createModalSkipNavigate}
+    onclose={onclosecreate}
+  />
+{:else if createModalState.error && showCreateModal}
+  <!-- shortcut-guard-exempt: retrying a failed lazy import is a recovery action, not a form submission. -->
+  <ModalBackdrop show={true} opacity={0.4} closeOnClick={false} onclose={onclosecreate}>
+    <div class="rounded-xl p-6 text-center" role="alert" data-testid="create-modal-load-error" style="background-color: var(--ds-surface-raised); color: var(--ds-text);">
+      <p class="font-semibold">Failed to load Create Form</p>
+      <p class="mt-1 text-sm" style="color: var(--ds-text-subtle);">Check your connection, then try again.</p>
+      <div class="mt-4 flex justify-center gap-2">
+        <Button variant="secondary" onclick={onclosecreate}>{t('common.close')}</Button>
+        <Button variant="primary" onclick={() => lazyComponents.retry('create-modal')}>{t('nav.retry')}</Button>
+      </div>
+    </div>
+  </ModalBackdrop>
+{/if}
+
+<GlobalConfirmDialog />
+
+{#if desktopBridge.modal === 'pomodoro-settings' && PomodoroSettingsModalComponent}
+  <PomodoroSettingsModalComponent show={true} onclose={() => desktopBridge.close()} />
+{:else if desktopBridge.modal === 'about' && AboutModalComponent}
+  <AboutModalComponent show={true} onclose={() => desktopBridge.close()} />
+{/if}
+
+<FloatingTimer />
+
+{#if aiStore.chatAvailable && showChatPanel && chatPanelState.component}
+  {@const ChatPanelComponent = chatPanelState.component}
+  <ChatPanelComponent bind:isOpen={showChatPanel} onclose={() => showChatPanel = false} />
+{/if}
+
+<ToastContainer />

--- a/frontend/src/lib/pages/MainRouteContent.svelte
+++ b/frontend/src/lib/pages/MainRouteContent.svelte
@@ -1,0 +1,186 @@
+<script>
+  import Button from '../components/Button.svelte';
+  import Spinner from '../components/Spinner.svelte';
+  import Channels from '../features/channels/Channels.svelte';
+  import Collections from '../features/collections/Collections.svelte';
+  import CollectionsList from '../features/collections/CollectionsList.svelte';
+  import PermissionGuard from '../layout/PermissionGuard.svelte';
+  import { authStore, workspacesStore } from '../stores';
+  import { t } from '../stores/i18n.svelte.js';
+  import { moduleSettings } from '../stores/moduleSettings.js';
+  import TeamDetail from '../teams/TeamDetail.svelte';
+  import TeamsList from '../teams/TeamsList.svelte';
+  import Customers from '../workspaces/Customers.svelte';
+  import WorkspaceSettings from '../workspaces/WorkspaceSettings.svelte';
+  import ApprovalsInbox from './ApprovalsInbox.svelte';
+  import About from './About.svelte';
+  import ApiDocs from './ApiDocs.svelte';
+  import CliAuthorize from './CliAuthorize.svelte';
+  import Hub from '../layout/Hub.svelte';
+  import NotFound from './NotFound.svelte';
+  import NotificationsPage from './NotificationsPage.svelte';
+  import OAuthAuthorize from './OAuthAuthorize.svelte';
+  import SearchPage from './SearchPage.svelte';
+  import Security from './Security.svelte';
+  import UnauthorizedAccess from './UnauthorizedAccess.svelte';
+  import UserProfile from './UserProfile.svelte';
+  import Workspaces from '../workspaces/Workspaces.svelte';
+  import {
+    getMainAppLazyState,
+    getMainAppRouteProps,
+    resolveMainAppRoute,
+    WORKSPACE_SETTINGS_TABS,
+    WORKSPACE_SETTINGS_VIEWS,
+  } from './mainAppRoutes.js';
+
+  let { view, route, lazyComponents } = $props();
+
+  const routeEntry = $derived(resolveMainAppRoute(view));
+  const wrapper = $derived(routeEntry.config?.wrapper || null);
+  const routeProps = $derived.by(() =>
+    getMainAppRouteProps(view, route, {
+      currentUser: authStore.currentUser,
+      moduleSettings: $moduleSettings,
+      personalWorkspaceId: $workspacesStore.personalWorkspace?.id,
+    })
+  );
+
+  $effect(() => {
+    if (routeEntry.key) void lazyComponents.load(routeEntry.key);
+  });
+</script>
+
+{#snippet loadingState(message)}
+  <div class="flex items-center justify-center h-full">
+    <div class="text-center">
+      <Spinner class="mx-auto mb-4" />
+      <p class="text-gray-600">{message}</p>
+    </div>
+  </div>
+{/snippet}
+
+{#snippet errorState(message, retryFn)}
+  <div class="flex items-center justify-center h-full">
+    <div class="text-center">
+      <p class="text-red-600">{message}</p>
+      <Button variant="primary" onclick={retryFn} class="mt-4">
+        {t('nav.retry')}
+      </Button>
+    </div>
+  </div>
+{/snippet}
+
+{#snippet lazyLoadedComponent(lazyView, props)}
+  {@const state = getMainAppLazyState(lazyComponents, lazyView)}
+
+  {#if state.loading}
+    {@render loadingState(state.config?.loadingMsg || 'Loading...')}
+  {:else if state.component}
+    {@const LazyComponent = state.component}
+    <LazyComponent {...props} />
+  {:else if state.error}
+    {@render errorState(
+      state.config?.errorMsg || 'Failed to load component',
+      () => lazyComponents.retry(state.loaderKey)
+    )}
+  {:else}
+    {@render loadingState(state.config?.loadingMsg || 'Loading...')}
+  {/if}
+{/snippet}
+
+{#if view === 'workspaces'}
+  <Workspaces showAdminHeader={false} />
+{:else if WORKSPACE_SETTINGS_VIEWS.has(view)}
+  <div class="p-6" style="background-color: var(--ds-surface);">
+    <WorkspaceSettings
+      workspaceId={route.params.id}
+      activeTab={WORKSPACE_SETTINGS_TABS[view] || 'general'}
+    />
+  </div>
+{:else if view === 'collections-list'}
+  <CollectionsList />
+{:else if view === 'collections-edit'}
+  <Collections collectionId={route.params.id} />
+{:else if view === 'channels'}
+  <div style="background-color: var(--ds-surface);">
+    <Channels />
+  </div>
+{:else if view === 'hub' || view === 'hub-inbox'}
+  <div style="background-color: var(--ds-surface);">
+    <Hub />
+  </div>
+{:else if view === 'organizations' || view === 'organization-contact-detail'}
+  <Customers />
+{:else if view === 'teams-list'}
+  <div class="p-6" style="background-color: var(--ds-surface);">
+    <TeamsList />
+  </div>
+{:else if view === 'team-detail'}
+  <div class="p-6" style="background-color: var(--ds-surface);">
+    <TeamDetail teamId={route.params.id} section={route.params.section || 'overview'} />
+  </div>
+{:else if view === 'notifications'}
+  <NotificationsPage />
+{:else if view === 'approvals-inbox'}
+  <ApprovalsInbox />
+{:else if view === 'search'}
+  <SearchPage />
+{:else if view === 'profile'}
+  <div class="p-6" style="background-color: var(--ds-surface);">
+    <UserProfile />
+  </div>
+{:else if view === 'security'}
+  <div class="p-6" style="background-color: var(--ds-surface);">
+    <Security />
+  </div>
+{:else if view === 'about'}
+  <About />
+{:else if view === 'api-docs'}
+  <ApiDocs />
+{:else if view === 'cli-authorize'}
+  <CliAuthorize />
+{:else if view === 'oauth-authorize'}
+  <OAuthAuthorize />
+{:else if view === '404'}
+  <div class="p-6" style="background-color: var(--ds-surface);">
+    <NotFound />
+  </div>
+{:else if view === 'admin'}
+  {#if route.path.startsWith('/admin/channels')}
+    {@render lazyLoadedComponent(view, routeProps)}
+  {:else}
+    <PermissionGuard requireSystemAdmin={true}>
+      {#snippet children()}
+        {@render lazyLoadedComponent(view, routeProps)}
+      {/snippet}
+      {#snippet fallback(requiredPermissionDisplay)}
+        <UnauthorizedAccess
+          message="You need system administrator privileges to access the administration panel."
+          requiredPermission={requiredPermissionDisplay}
+        />
+      {/snippet}
+    </PermissionGuard>
+  {/if}
+{:else if view === 'workspace-actions'}
+  <div class="h-full" style="background-color: var(--ds-surface); height: calc(100vh - 56px);">
+    {@render lazyLoadedComponent(view, routeProps)}
+  </div>
+{:else if routeEntry.config}
+  {#if wrapper === 'surface-full'}
+    <div style="background-color: var(--ds-surface);">
+      {@render lazyLoadedComponent(view, routeProps)}
+    </div>
+  {:else if wrapper === 'surface-padded'}
+    <div class="p-6" style="background-color: var(--ds-surface);">
+      {@render lazyLoadedComponent(view, routeProps)}
+    </div>
+  {:else if wrapper === 'surface-admin'}
+    <div class="px-16 py-12 flex-1 overflow-y-auto" style="background-color: var(--ds-surface);">
+      {@render lazyLoadedComponent(view, routeProps)}
+    </div>
+  {:else}
+    {@render lazyLoadedComponent(view, routeProps)}
+  {/if}
+{:else}
+  <Workspaces showAdminHeader={false} />
+{/if}

--- a/frontend/src/lib/pages/mainAppRoutes.js
+++ b/frontend/src/lib/pages/mainAppRoutes.js
@@ -1,0 +1,440 @@
+// Keep every dynamic import literal in one registry so Vite preserves the
+// existing route-level chunks while MainApp remains a small composition root.
+export const MAIN_APP_COMPONENT_LOADERS = {
+  admin: () => import('./Admin.svelte'),
+  time: () => import('../features/time/Time.svelte'),
+  'test-cases': () => import('../features/testing/TestCases.svelte'),
+  'test-sets': () => import('../features/testing/TestSets.svelte'),
+  'test-templates': () => import('../features/testing/TestTemplates.svelte'),
+  'test-runs': () => import('../features/testing/TestRuns.svelte'),
+  'test-reports': () => import('../features/testing/TestReports.svelte'),
+  'test-steps': () => import('../features/testing/TestSteps.svelte'),
+  'test-execution': () => import('../features/testing/TestExecution.svelte'),
+  'test-run-detail': () => import('../features/testing/TestRunDetail.svelte'),
+  'test-template-detail': () => import('../features/testing/TestTemplateDetail.svelte'),
+  milestones: () => import('../features/milestones/Milestones.svelte'),
+  'milestone-detail': () => import('../features/milestones/MilestoneDetail.svelte'),
+  iterations: () => import('../features/iterations/Iterations.svelte'),
+  'iteration-detail': () => import('../features/iterations/IterationDetail.svelte'),
+  'iteration-dependencies': () => import('../features/iterations/IterationDependencies.svelte'),
+  assets: () => import('../features/assets/AssetBrowser.svelte'),
+  'asset-detail': () => import('../features/assets/AssetBrowser.svelte'),
+  'asset-settings': () => import('../features/assets/AssetManager.svelte'),
+  'channel-manager': () => import('../features/channels/ManagerChannels.svelte'),
+  'workspace-board': () => import('../features/collections/CollectionBoard.svelte'),
+  'workspace-board-config': () => import('../settings/BoardConfigurationPage.svelte'),
+  'workspace-backlog': () => import('../features/collections/CollectionBacklog.svelte'),
+  'workspace-list': () => import('../features/collections/CollectionList.svelte'),
+  'workspace-tree': () => import('../features/collections/CollectionTree.svelte'),
+  'workspace-map': () => import('../features/collections/CollectionMap.svelte'),
+  'workspace-roadmap': () => import('../features/collections/CollectionRoadmap.svelte'),
+  'workspace-pages': () => import('../features/pages/PagesView.svelte'),
+  'workspace-pages-archived': () => import('../features/pages/ArchivedPagesPage.svelte'),
+  'collection-board': () => import('../features/collections/CollectionBoard.svelte'),
+  'collection-board-config': () => import('../settings/BoardConfigurationPage.svelte'),
+  'collection-backlog': () => import('../features/collections/CollectionBacklog.svelte'),
+  'collection-list': () => import('../features/collections/CollectionList.svelte'),
+  'collection-tree': () => import('../features/collections/CollectionTree.svelte'),
+  'collection-map': () => import('../features/collections/CollectionMap.svelte'),
+  'collection-roadmap': () => import('../features/collections/CollectionRoadmap.svelte'),
+  'workspace-iterations': () => import('../features/iterations/Iterations.svelte'),
+  'workspace-milestones': () => import('../features/milestones/Milestones.svelte'),
+  'workspace-actions': () => import('../features/actions/ActionsSettings.svelte'),
+  'workspace-analytics': () => import('../features/analytics/WorkspaceAnalytics.svelte'),
+  'workspace-agents': () => import('../features/agents/AgentCatalog.svelte'),
+  'workspace-agent-create': () => import('../features/agents/AgentCreate.svelte'),
+  'workspace-agent-profile': () => import('../features/agents/AgentProfile.svelte'),
+  'command-palette': () => import('../layout/CommandPalette.svelte'),
+  'create-modal': () => import('../dialogs/CreateModal.svelte'),
+  homepage: () => import('./Homepage.svelte'),
+  licenses: () => import('./Licenses.svelte'),
+  'item-detail': () => import('../features/items/ItemDetail.svelte'),
+  'personal-task-detail': () => import('../features/personal/PersonalTaskDetail.svelte'),
+  'workspace-detail': () => import('../workspaces/WorkspaceWelcome.svelte'),
+  'workspace-overview': () => import('../workspaces/WorkspaceWelcome.svelte'),
+  'personal-workspace': () => import('../workspaces/WorkspaceDetail.svelte'),
+  'workspace-calendar': () => import('../features/time/WeeklyCalendar.svelte'),
+  'workspace-reviews': () => import('../features/personal/PersonalReview.svelte'),
+  'workflow-designer': () => import('../features/workflows/WorkflowDesigner.svelte'),
+  'configuration-set-detail': () => import('../settings/ConfigurationSetDetail.svelte'),
+  'workspace-look-and-feel': () => import('../workspaces/WorkspaceLookAndFeel.svelte'),
+  'personal-plan': () => import('../features/personal/PlanMyDay.svelte'),
+  logbook: () => import('../features/logbook/Logbook.svelte'),
+  'logbook-document': () => import('../features/logbook/DocumentDetail.svelte'),
+  'chat-panel': () => import('../features/chat/ChatPanel.svelte'),
+  'terminal-panel': () => import('../features/terminal/TerminalPanel.svelte'),
+};
+
+const route = (loadingMsg, errorMsg, options = {}) => ({ loadingMsg, errorMsg, ...options });
+const workspaceCollectionProps = (currentRoute) => ({
+  workspaceId: currentRoute.params.id,
+  collectionId: currentRoute.params.collectionId,
+});
+const globalCollectionProps = (currentRoute) => ({
+  workspaceId: null,
+  collectionId: currentRoute.params.id,
+});
+const workspaceProps = (currentRoute) => ({ workspaceId: currentRoute.params.id });
+
+/**
+ * @typedef {object} MainAppRouteConfig
+ * @property {string} [loadingMsg]
+ * @property {string} [errorMsg]
+ * @property {string} [wrapper]
+ * @property {string} [requirePermission]
+ * @property {string} [trigger]
+ * @property {string[]} [matchViews]
+ * @property {(currentRoute: any, context: any) => Record<string, any>} [getProps]
+ */
+
+/** @type {Record<string, MainAppRouteConfig>} */
+export const MAIN_APP_ROUTE_CONFIG = {
+  admin: route('Loading Admin Panel...', 'Failed to load Admin Panel', {
+    requirePermission: 'systemAdmin',
+  }),
+  time: route('Loading Time & Projects...', 'Failed to load Time & Projects'),
+  'test-cases': route('Loading Test Cases...', 'Failed to load Test Cases', {
+    wrapper: 'none',
+    getProps: workspaceProps,
+  }),
+  'test-sets': route('Loading Test Plans...', 'Failed to load Test Plans', {
+    wrapper: 'none',
+    getProps: workspaceProps,
+  }),
+  'test-templates': route('Loading Test Templates...', 'Failed to load Test Templates', {
+    wrapper: 'none',
+    getProps: workspaceProps,
+  }),
+  'test-runs': route('Loading Test Runs...', 'Failed to load Test Runs', {
+    wrapper: 'none',
+    getProps: workspaceProps,
+  }),
+  'test-reports': route('Loading Test Reports...', 'Failed to load Test Reports', {
+    wrapper: 'none',
+    getProps: workspaceProps,
+  }),
+  'test-steps': route('Loading Test Steps...', 'Failed to load Test Steps', {
+    wrapper: 'none',
+    getProps: workspaceProps,
+  }),
+  'test-execution': route('Loading Test Execution...', 'Failed to load Test Execution', {
+    wrapper: 'none',
+  }),
+  'test-run-detail': route('Loading Test Run Details...', 'Failed to load Test Run Details', {
+    wrapper: 'none',
+  }),
+  'test-template-detail': route('Loading Template Details...', 'Failed to load Template Details', {
+    wrapper: 'none',
+  }),
+  milestones: route('Loading Milestones...', 'Failed to load Milestones', {
+    wrapper: 'surface-full',
+  }),
+  'milestone-detail': route('Loading Milestone...', 'Failed to load Milestone', {
+    wrapper: 'surface-full',
+    getProps: (currentRoute) => ({
+      milestoneId: currentRoute.params.id,
+      workspaceId: currentRoute.query?.workspaceId || null,
+    }),
+  }),
+  iterations: route('Loading Iterations...', 'Failed to load Iterations', {
+    wrapper: 'surface-full',
+    getProps: (currentRoute) => ({ typeId: currentRoute.params.typeId }),
+  }),
+  'iteration-detail': route('Loading Iteration...', 'Failed to load Iteration', {
+    wrapper: 'surface-full',
+    getProps: (currentRoute) => ({
+      iterationId: currentRoute.params.id,
+      workspaceId: currentRoute.query?.workspaceId || null,
+    }),
+  }),
+  'iteration-dependencies': route(
+    'Loading Dependency Analysis...',
+    'Failed to load Dependency Analysis',
+    {
+      wrapper: 'surface-full',
+      getProps: (currentRoute) => ({ iterationId: currentRoute.params.id }),
+    }
+  ),
+  assets: route('Loading Assets...', 'Failed to load Assets', { wrapper: 'surface-full' }),
+  'channel-manager': route('Loading Channels...', 'Failed to load Channels', {
+    wrapper: 'surface-padded',
+  }),
+  'asset-detail': route('Loading Asset...', 'Failed to load Asset', {
+    wrapper: 'surface-full',
+    getProps: (currentRoute) => ({ assetId: currentRoute.params.id }),
+  }),
+  'asset-settings': route('Loading Asset Settings...', 'Failed to load Asset Settings', {
+    wrapper: 'surface-admin',
+  }),
+  'workspace-board': route('Loading Board View...', 'Failed to load Board View', {
+    getProps: workspaceCollectionProps,
+  }),
+  'workspace-board-config': route(
+    'Loading Board Configuration...',
+    'Failed to load Board Configuration',
+    { getProps: workspaceCollectionProps }
+  ),
+  'workspace-backlog': route('Loading Backlog View...', 'Failed to load Backlog View', {
+    getProps: workspaceCollectionProps,
+  }),
+  'workspace-list': route('Loading List View...', 'Failed to load List View', {
+    getProps: workspaceCollectionProps,
+  }),
+  'workspace-tree': route('Loading Tree View...', 'Failed to load Tree View', {
+    getProps: workspaceCollectionProps,
+  }),
+  'workspace-map': route('Loading Map View...', 'Failed to load Map View', {
+    getProps: workspaceCollectionProps,
+  }),
+  'workspace-roadmap': route('Loading Roadmap...', 'Failed to load Roadmap', {
+    getProps: workspaceCollectionProps,
+  }),
+  'workspace-pages': route('Loading Pages...', 'Failed to load Pages', {
+    wrapper: 'none',
+    getProps: (currentRoute) => ({
+      workspaceId: Number(currentRoute.params.id),
+      pageId: currentRoute.params.pageId ? Number(currentRoute.params.pageId) : null,
+    }),
+  }),
+  'workspace-pages-archived': route('Loading Archived Pages...', 'Failed to load Archived Pages', {
+    wrapper: 'none',
+    getProps: (currentRoute) => ({ workspaceId: Number(currentRoute.params.id) }),
+  }),
+  'collection-board': route('Loading Board View...', 'Failed to load Board View', {
+    getProps: globalCollectionProps,
+  }),
+  'collection-board-config': route(
+    'Loading Board Configuration...',
+    'Failed to load Board Configuration',
+    { getProps: globalCollectionProps }
+  ),
+  'collection-backlog': route('Loading Backlog View...', 'Failed to load Backlog View', {
+    getProps: globalCollectionProps,
+  }),
+  'collection-list': route('Loading List View...', 'Failed to load List View', {
+    getProps: globalCollectionProps,
+  }),
+  'collection-tree': route('Loading Tree View...', 'Failed to load Tree View', {
+    getProps: globalCollectionProps,
+  }),
+  'collection-map': route('Loading Map View...', 'Failed to load Map View', {
+    getProps: globalCollectionProps,
+  }),
+  'collection-roadmap': route('Loading Roadmap...', 'Failed to load Roadmap', {
+    getProps: globalCollectionProps,
+  }),
+  'workspace-iterations': route('Loading Iterations...', 'Failed to load Iterations', {
+    wrapper: 'surface-full',
+    getProps: workspaceProps,
+  }),
+  'workspace-milestones': route('Loading Milestones...', 'Failed to load Milestones', {
+    wrapper: 'surface-full',
+    getProps: workspaceProps,
+  }),
+  'workspace-actions': route('Loading Actions...', 'Failed to load Actions', {
+    wrapper: 'none',
+    getProps: (currentRoute) => ({
+      workspaceId: currentRoute.params.id,
+      actionId: Number(currentRoute.params.actionId) || 0,
+    }),
+  }),
+  'workspace-analytics': route('Loading Analytics...', 'Failed to load Analytics', {
+    wrapper: 'surface-full',
+    getProps: workspaceProps,
+  }),
+  'workspace-agents': route('Loading Agents...', 'Failed to load Agents', {
+    wrapper: 'surface-full',
+    getProps: workspaceProps,
+  }),
+  'workspace-agent-create': route('Opening Agent Studio...', 'Failed to open Agent Studio', {
+    wrapper: 'surface-full',
+    getProps: workspaceProps,
+  }),
+  'workspace-agent-profile': route('Loading Agent...', 'Failed to load Agent', {
+    wrapper: 'surface-full',
+    getProps: (currentRoute) => ({
+      workspaceId: currentRoute.params.id,
+      agentId: currentRoute.params.agentId,
+      tab: currentRoute.query?.tab,
+    }),
+  }),
+  'command-palette': { trigger: 'showCommandPalette' },
+  'create-modal': { trigger: 'showCreateModal' },
+  homepage: route('Loading Homepage...', 'Failed to load Homepage', {
+    wrapper: 'surface-full',
+  }),
+  licenses: route('Loading Licenses...', 'Failed to load Licenses', {
+    wrapper: 'surface-full',
+  }),
+  'item-detail': route('Loading Item Details...', 'Failed to load Item Details', {
+    getProps: (currentRoute, context) => {
+      const personal = currentRoute.path.startsWith('/personal');
+      const workspaceParam = currentRoute.params.workspaceKey || currentRoute.params.id;
+      const itemParam =
+        currentRoute.params.itemKey || currentRoute.params.itemNumber || currentRoute.params.itemId;
+      const fullKeyMatch = !personal ? String(itemParam || '').match(/^([^/\s-]+)-(\d+)$/) : null;
+      const workspaceParamIsKey = !!workspaceParam && !/^\d+$/.test(String(workspaceParam));
+      const keyWorkspace = fullKeyMatch?.[1] || (workspaceParamIsKey ? workspaceParam : null);
+      const keyItemNumber = fullKeyMatch?.[2] || (keyWorkspace ? itemParam : null);
+
+      return {
+        workspaceId: personal ? context.personalWorkspaceId : keyWorkspace ? null : workspaceParam,
+        itemId: keyItemNumber || itemParam,
+        workspaceKey: !personal ? keyWorkspace : null,
+        itemNumber: !personal ? keyItemNumber : null,
+        canonicalizeKeyRoute: !personal && !!keyWorkspace,
+        tab: currentRoute.query.tab || 'comments',
+        moduleSettings: context.moduleSettings,
+      };
+    },
+  }),
+  'personal-task-detail': route('Loading Task...', 'Failed to load Task', {
+    getProps: (currentRoute, context) => ({
+      workspaceId: currentRoute.path.startsWith('/personal')
+        ? context.personalWorkspaceId
+        : currentRoute.params.id,
+      itemId: currentRoute.params.itemId,
+      isModal: false,
+    }),
+  }),
+  'workspace-detail': route('Loading Workspace...', 'Failed to load Workspace', {
+    getProps: workspaceCollectionProps,
+  }),
+  'workspace-overview': route('Loading Workspace...', 'Failed to load Workspace', {
+    getProps: workspaceCollectionProps,
+  }),
+  'personal-workspace': route(
+    'Loading Personal Workspace...',
+    'Failed to load Personal Workspace',
+    {
+      getProps: (_currentRoute, context) => ({ workspaceId: context.personalWorkspaceId }),
+    }
+  ),
+  'workspace-calendar': route('Loading Calendar...', 'Failed to load Calendar', {
+    wrapper: 'surface-full',
+    getProps: (currentRoute, context) => ({
+      workspaceId: currentRoute.path.startsWith('/personal')
+        ? context.personalWorkspaceId
+        : currentRoute.params.id,
+    }),
+  }),
+  'workspace-reviews': route('Loading Reviews...', 'Failed to load Reviews', {
+    wrapper: 'surface-full',
+    getProps: (currentRoute, context) => ({
+      currentUser: context.currentUser,
+      workspaceId: currentRoute.path.startsWith('/personal')
+        ? context.personalWorkspaceId
+        : currentRoute.params.id,
+    }),
+  }),
+  'workflow-designer': route('Loading workflow designer...', 'Failed to load workflow designer'),
+  'configuration-set-detail': route(
+    'Loading configuration set...',
+    'Failed to load configuration set'
+  ),
+  'workspace-look-and-feel': route('Loading Look and Feel...', 'Failed to load Look and Feel', {
+    wrapper: 'none',
+    getProps: workspaceProps,
+  }),
+  'personal-plan': route('Loading Plan My Day...', 'Failed to load Plan My Day', {
+    wrapper: 'surface-full',
+  }),
+  logbook: route('Loading Knowledge Base...', 'Failed to load Knowledge Base', {
+    wrapper: 'surface-full',
+  }),
+  'logbook-document': route('Loading Document...', 'Failed to load Document', {
+    wrapper: 'surface-full',
+    getProps: (currentRoute) => ({ documentId: currentRoute.params.documentId }),
+  }),
+};
+
+export const MAIN_APP_TEST_VIEWS = new Set([
+  'test-cases',
+  'test-sets',
+  'test-templates',
+  'test-runs',
+  'test-reports',
+  'test-steps',
+  'test-run-detail',
+  'test-template-detail',
+  'test-execution',
+  'test-case-detail',
+  'test-set-detail',
+]);
+
+export const WORKSPACE_SETTINGS_TABS = {
+  'workspace-settings-categories': 'categories',
+  'workspace-settings-members': 'members',
+  'workspace-settings-configuration': 'configuration',
+  'workspace-settings-source-control': 'source-control',
+  'workspace-settings-coding-agents': 'coding-agents',
+  'workspace-settings-issue-sync': 'issue-sync',
+  'workspace-settings-recurrence': 'recurrence',
+  'workspace-settings-templates': 'templates',
+  'workspace-settings-danger': 'danger',
+};
+
+export const WORKSPACE_SETTINGS_VIEWS = new Set([
+  'workspace-settings',
+  'workspace-settings-general',
+  ...Object.keys(WORKSPACE_SETTINGS_TABS),
+]);
+
+export const CREATE_MODAL_WORKSPACE_VIEWS = new Set([
+  'workspace-detail',
+  'workspace-calendar',
+  'workspace-reviews',
+  ...[...WORKSPACE_SETTINGS_VIEWS].filter((view) => view !== 'workspace-settings-recurrence'),
+  'workspace-look-and-feel',
+  'workspace-board',
+  'workspace-backlog',
+  'workspace-list',
+  'workspace-tree',
+  'workspace-map',
+  'workspace-roadmap',
+  'workspace-actions',
+  'item-detail',
+]);
+
+export function resolveMainAppRoute(view) {
+  if (!view) return { key: null, config: null };
+  if (MAIN_APP_ROUTE_CONFIG[view]) {
+    return { key: view, config: MAIN_APP_ROUTE_CONFIG[view] };
+  }
+
+  for (const [key, config] of Object.entries(MAIN_APP_ROUTE_CONFIG)) {
+    if (config.matchViews?.includes(view)) return { key, config };
+  }
+
+  return { key: null, config: null };
+}
+
+export function resolveEffectiveMainAppView(currentRoute, personalWorkspaceId) {
+  if (currentRoute.view !== 'item-detail') return currentRoute.view;
+
+  const workspaceId = currentRoute.path?.startsWith('/personal')
+    ? personalWorkspaceId
+    : Number.parseInt(currentRoute.params?.id, 10);
+
+  return personalWorkspaceId && workspaceId === personalWorkspaceId
+    ? 'personal-task-detail'
+    : currentRoute.view;
+}
+
+export function getMainAppRouteProps(view, currentRoute, context = {}) {
+  const { config } = resolveMainAppRoute(view);
+  return config?.getProps?.(currentRoute, context) || {};
+}
+
+export function getMainAppLazyState(lazyComponents, view) {
+  const { key, config } = resolveMainAppRoute(view);
+  const loaderKey = key || view;
+
+  return {
+    component: lazyComponents.getComponent(view) || (key ? lazyComponents.getComponent(key) : null),
+    loading: lazyComponents.isLoading(view) || Boolean(key && lazyComponents.isLoading(key)),
+    error: lazyComponents.getError(view) || (key ? lazyComponents.getError(key) : null),
+    config,
+    loaderKey,
+  };
+}

--- a/frontend/src/lib/pages/mainAppWorkspaceContext.js
+++ b/frontend/src/lib/pages/mainAppWorkspaceContext.js
@@ -1,0 +1,53 @@
+import { GLOBAL_COLLECTION_VIEWS } from '../router.js';
+import { MAIN_APP_TEST_VIEWS } from './mainAppRoutes.js';
+
+function isPersonalWorkspaceView(view) {
+  return (
+    view?.startsWith('workspace-') ||
+    view === 'personal-workspace' ||
+    view === 'personal-plan' ||
+    view === 'item-detail'
+  );
+}
+
+function isRegularWorkspaceView(view) {
+  return (
+    view?.startsWith('workspace-') ||
+    view === 'workspace' ||
+    view === 'item-detail' ||
+    view === 'item' ||
+    MAIN_APP_TEST_VIEWS.has(view)
+  );
+}
+
+export function resolveMainAppWorkspaceContext(currentRoute, personalWorkspaceId) {
+  if (currentRoute.path?.startsWith('/personal') && isPersonalWorkspaceView(currentRoute.view)) {
+    return personalWorkspaceId
+      ? { kind: 'workspace', workspaceId: personalWorkspaceId }
+      : { kind: 'personal-pending' };
+  }
+
+  if (
+    currentRoute.params?.id &&
+    /^\d+$/.test(String(currentRoute.params.id)) &&
+    isRegularWorkspaceView(currentRoute.view)
+  ) {
+    return { kind: 'workspace', workspaceId: currentRoute.params.id };
+  }
+
+  return GLOBAL_COLLECTION_VIEWS.has(currentRoute.view)
+    ? { kind: 'global-collection' }
+    : { kind: 'none' };
+}
+
+export function getMainAppWorkspaceRedirect(currentRoute, activeWorkspace) {
+  if (currentRoute.view !== 'workspace-detail' || !activeWorkspace) return null;
+  const workspaceId = currentRoute.params?.id;
+  if (!workspaceId) return null;
+
+  const collectionId = currentRoute.params?.collectionId;
+  const base = collectionId
+    ? `/workspaces/${workspaceId}/collections/${collectionId}`
+    : `/workspaces/${workspaceId}`;
+  return `${base}/${activeWorkspace.default_view || 'board'}`;
+}

--- a/frontend/src/lib/pages/useMainAppLifecycle.js
+++ b/frontend/src/lib/pages/useMainAppLifecycle.js
@@ -1,0 +1,177 @@
+import { useEventListener } from 'runed';
+import { onMount } from 'svelte';
+import { ADMIN_UI_MUTATION_EVENT } from '../api/core.js';
+import { api } from '../api.js';
+import { desktopBridge } from '../desktop/bridge.svelte.js';
+import {
+  resetAuthenticatedShellState,
+  runAuthenticatedShellBootstrap,
+} from '../services/authenticatedShellBootstrap.js';
+import {
+  hydrateAuthenticatedShellUI,
+  refreshAuthenticatedShellUI,
+} from '../services/authenticatedShellUI.js';
+import {
+  activityStore,
+  authStore,
+  homepageStore,
+  permissionStore,
+  ssoStore,
+  workspaceDataStore,
+  workspacePermissions,
+  workspacesStore,
+} from '../stores';
+import { capabilitiesStore } from '../stores/capabilities.svelte.js';
+import { startNotificationPoller, stopNotificationPoller } from '../stores/notifications.js';
+import { initDesktopFocusRefresh } from '../utils/desktopFocusRefresh.svelte.js';
+
+const DOUBLE_SPACE_THRESHOLD_MS = 300;
+const ADMIN_UI_REFRESH_DEBOUNCE_MS = 75;
+
+/**
+ * Own the authenticated shell's process-level lifecycle and translate global
+ * browser events into the small set of UI actions MainApp composes.
+ */
+export function useMainAppLifecycle({
+  onEmailVerificationChange,
+  onShowCommandPalette,
+  onShowCreateModal,
+}) {
+  let lastSpaceTime = 0;
+  let adminUIRefreshTimer = null;
+  let adminUIRefreshPromise = null;
+  let adminUIRefreshQueued = false;
+
+  capabilitiesStore.beginHydration();
+
+  async function runAdminUIRefresh() {
+    if (adminUIRefreshPromise) {
+      adminUIRefreshQueued = true;
+      return adminUIRefreshPromise;
+    }
+
+    do {
+      adminUIRefreshQueued = false;
+      adminUIRefreshPromise = refreshAuthenticatedShellUI();
+      try {
+        await adminUIRefreshPromise;
+      } finally {
+        adminUIRefreshPromise = null;
+      }
+    } while (adminUIRefreshQueued);
+  }
+
+  function scheduleAdminUIRefresh() {
+    if (adminUIRefreshTimer) clearTimeout(adminUIRefreshTimer);
+    adminUIRefreshTimer = setTimeout(() => {
+      adminUIRefreshTimer = null;
+      void runAdminUIRefresh();
+    }, ADMIN_UI_REFRESH_DEBOUNCE_MS);
+  }
+
+  onMount(() => {
+    activityStore.init();
+    initDesktopFocusRefresh();
+    desktopBridge.init();
+    startNotificationPoller();
+
+    const user = authStore.currentUser;
+    const userId = user?.id;
+    const criticalTasks = [
+      () => workspacesStore.load(),
+      () => permissionStore.loadAllPermissions(user),
+    ];
+    if (userId) {
+      criticalTasks.push(
+        () => permissionStore.loadUserPermissions(userId),
+        () => workspacePermissions.loadPermissions(userId)
+      );
+    }
+
+    const deferredTasks = [
+      () => workspacesStore.loadPersonalWorkspace(),
+      async () => {
+        try {
+          const bootstrap = await api.shellBootstrap.get();
+          hydrateAuthenticatedShellUI(bootstrap);
+        } catch (error) {
+          capabilitiesStore.failHydration();
+          console.warn('Failed to load shell capabilities:', error);
+        }
+      },
+      async () => {
+        if (ssoStore.checkForEmailVerificationPending()) {
+          onEmailVerificationChange(true);
+          return;
+        }
+
+        try {
+          const status = await ssoStore.getVerificationStatus();
+          onEmailVerificationChange(Boolean(status.configured && !status.email_verified));
+        } catch (error) {
+          console.warn('Failed to check email verification status:', error);
+        }
+      },
+    ];
+
+    void runAuthenticatedShellBootstrap({
+      userId,
+      criticalTasks,
+      deferredTasks,
+      onMeasured: (metrics) => {
+        window.dispatchEvent(
+          new CustomEvent('windshift:auth-shell-bootstrap', { detail: metrics })
+        );
+      },
+    });
+
+    return () => {
+      stopNotificationPoller();
+      homepageStore.reset();
+      resetAuthenticatedShellState();
+    };
+  });
+
+  useEventListener(
+    () => document,
+    'keydown',
+    (event) => {
+      if (event.code !== 'Space') return;
+
+      const target = /** @type {HTMLElement} */ (event.target);
+      const isInInputField =
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.contentEditable === 'true' ||
+        target.closest('[contenteditable="true"]');
+      if (isInInputField) return;
+
+      const now = Date.now();
+      if (now - lastSpaceTime < DOUBLE_SPACE_THRESHOLD_MS) onShowCommandPalette();
+      event.preventDefault();
+      lastSpaceTime = now;
+    }
+  );
+
+  onMount(() => {
+    const handleShowCreateModal = (event) => onShowCreateModal(event.detail || {});
+    const handleRefreshWorkspaces = () => void workspacesStore.reload();
+    const handleRefreshWorkspaceData = () => void workspaceDataStore.refresh();
+    const handleRefreshWorkItems = () => homepageStore.invalidateSnapshot();
+
+    window.addEventListener('show-create-modal', handleShowCreateModal);
+    window.addEventListener(ADMIN_UI_MUTATION_EVENT, scheduleAdminUIRefresh);
+    window.addEventListener('refresh-workspaces', handleRefreshWorkspaces);
+    window.addEventListener('refresh-workspace-data', handleRefreshWorkspaceData);
+    window.addEventListener('refresh-work-items', handleRefreshWorkItems);
+
+    return () => {
+      window.removeEventListener('show-create-modal', handleShowCreateModal);
+      window.removeEventListener(ADMIN_UI_MUTATION_EVENT, scheduleAdminUIRefresh);
+      window.removeEventListener('refresh-workspaces', handleRefreshWorkspaces);
+      window.removeEventListener('refresh-workspace-data', handleRefreshWorkspaceData);
+      window.removeEventListener('refresh-work-items', handleRefreshWorkItems);
+      if (adminUIRefreshTimer) clearTimeout(adminUIRefreshTimer);
+    };
+  });
+}


### PR DESCRIPTION
## Summary

- reduce `MainApp.svelte` from 1,555 lines to a 487-line composition and layout root
- extract the lazy route registry, route rendering, route props, and workspace-context synchronization
- extract authenticated-shell lifecycle wiring and global overlay/modal hosting
- preserve literal route-level imports and the shared lazy-loader recovery path
- preserve the Teams routes introduced on current `main` during rebase

## Validation

- `npm run check`
- `npm run typecheck` (0 errors, 0 warnings)
- `npm run build` (entry asset guard passed)
- focused Vitest coverage: 4 files, 11 tests
- full overlaid frontend coverage suite: 163 files, 1,041 tests

Companion tests: https://github.com/Windshiftapp/core-tests/pull/2

Task: WI-980