### PR TITLE
fix(frontend): keep description hover from shifting layout

### DIFF
--- a/frontend/src/lib/features/items/ItemDetailDescription.svelte
+++ b/frontend/src/lib/features/items/ItemDetailDescription.svelte
@@ -171,7 +171,7 @@
       onkeydown={(e) => e.key === 'Enter' && startEditingDescription()}
       role="button"
       tabindex="0"
-      class="description-hover text-left w-full rounded cursor-pointer transition-all duration-150"
+      class="description-hover text-left rounded cursor-pointer transition-colors duration-150"
       style="color: var(--ds-text);"
       title={t('items.clickToEditDescription')}
       data-testid="item-description-display"
@@ -309,10 +309,14 @@
 
 <style>
   .description-hover {
-    padding: 0;
+    /* constant padding with compensating negative margin: hover must only
+       repaint — a padding change on hover resizes the box and re-wraps the
+       description text, which reads as a wiggle */
+    width: calc(100% + 1rem);
+    padding: 0.5rem;
+    margin: -0.5rem;
   }
   .description-hover:hover {
-    padding: 0.5rem;
     background-color: var(--ds-background-input-hovered);
   }
   .action-btn {


### PR DESCRIPTION
## Problem

Hovering the read-only ticket description makes the text visibly "wiggle": the hover-to-edit affordance grows the wrapper's padding from `0` to `0.5rem`, animated by `transition-all duration-150`. The box resizes, the embedded ProseMirror content loses 16px of width and re-wraps, and everything below shifts down — on every hover in and out.

Isolated on a live v0.8.4 instance via CDP (forced `:hover` + computed-style diff): only `padding` and `background-color` change on hover, and forcing the hover padding back to `0` (background kept) makes the geometry fully static — the padding delta is the sole cause.

## Fix

Make the wrapper's geometry hover-invariant while keeping the padded-highlight look:

- constant `padding: 0.5rem` with compensating `margin: -0.5rem` and `width: calc(100% + 1rem)` (replaces `w-full`) — with border-box sizing, the resting text position, content width, and occupied space are pixel-identical to before;
- `:hover` now changes only `background-color`;
- `transition-all` → `transition-colors`, so no layout-affecting property can animate on this element.

`.description-hover` is scoped to this component and used nowhere else.

## Verification

- `npm run check`, `npm run typecheck`, `npm run build` all pass.
- Deployed a v0.8.4 + this-commit build against a live instance: hover geometry static (rAF sampling: one distinct geometry tuple across repeated hover in/out), highlight intact, resting layout unchanged to the pixel.
