### PR TITLE
fix(auth): use calendar dates for API token expiry

### DIFF
--- a/frontend/src/lib/pages/Security.svelte
+++ b/frontend/src/lib/pages/Security.svelte
@@ -731,7 +731,7 @@
 			</div>
 
 			<div>
-				<Label for="token-expiry" color="default" class="mb-1">Expiration (Optional)</Label>
+				<Label for="token-expiry" color="default" class="mb-1">Last valid date (optional)</Label>
 				<input
 					id="token-expiry"
 					type="date"
@@ -741,7 +741,7 @@
 					class="w-full px-3 py-2 rounded border transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50"
 					style="background-color: var(--ds-background-input); border-color: var(--ds-border); color: var(--ds-text);"
 				/>
-				<DescriptionText>Leave empty for tokens that never expire</DescriptionText>
+				<DescriptionText>The token remains valid through this date in your configured timezone. Leave empty for no expiration.</DescriptionText>
 			</div>
 		</div>
 

--- a/frontend/src/lib/pages/UserProfile.svelte
+++ b/frontend/src/lib/pages/UserProfile.svelte
@@ -16,7 +16,7 @@
 	import PersonalLabelManager from '../features/labels/PersonalLabelManager.svelte';
 	import LeavePeriods from '../profile/LeavePeriods.svelte';
 	import { copyToClipboard } from '../utils/clipboard.js';
-	import { dateInputToISOString, formatDate, formatDateSimple, formatDateShort } from '../utils/dateFormatter.js';
+	import { formatDate, formatDateSimple, formatDateShort } from '../utils/dateFormatter.js';
 	import { t, i18n, SUPPORTED_LOCALES } from '../stores/i18n.svelte.js';
 	import { confirm } from '../composables/useConfirm.js';
 	import DescriptionText from '../components/DescriptionText.svelte';
@@ -156,11 +156,9 @@
 		try {
 			const payload = {
 				name: s.name,
-				user_id: agentId
+				user_id: agentId,
+				expires_on: s.expiresAt || null
 			};
-			if (s.expiresAt) {
-				payload.expires_at = dateInputToISOString(s.expiresAt);
-			}
 			const result = await api.createApiToken(payload);
 			s.token = result?.token || result?.api_token?.token || '';
 			s.name = '';
@@ -1017,7 +1015,7 @@
 												<Input placeholder={t('security.tokenName')} bind:value={agentMintState[agent.id].name} />
 												<Input type="date" bind:value={agentMintState[agent.id].expiresAt} />
 											</div>
-											<DescriptionText>Leave expiration empty for tokens that never expire.</DescriptionText>
+											<DescriptionText>The token remains valid through this date in your configured timezone. Leave empty for no expiration.</DescriptionText>
 											{#if agentMintState[agent.id].error}
 												<p class="text-sm mt-2" style="color: var(--ds-text-danger);">{agentMintState[agent.id].error}</p>
 											{/if}

--- a/frontend/src/lib/settings/UserManager.svelte
+++ b/frontend/src/lib/settings/UserManager.svelte
@@ -58,7 +58,7 @@
 	let showTokenModal = $state(false);
 	let tokenTargetUser = $state(null);
 	let newTokenName = $state('');
-	let newTokenExpiresDays = $state(90);
+	let newTokenExpiry = $state('');
 	let newTokenScopes = $state([]);
 	let creatingToken = $state(false);
 	let mintedToken = $state('');
@@ -377,7 +377,7 @@
 	function openTokenModal(user) {
 		tokenTargetUser = user;
 		newTokenName = `${user.username}-token`;
-		newTokenExpiresDays = 90;
+		newTokenExpiry = '';
 		newTokenScopes = [...defaultAgentTokenScopes];
 		mintedToken = '';
 		mintedTokenError = '';
@@ -407,13 +407,9 @@
 			const payload = {
 				name: newTokenName,
 				user_id: tokenTargetUser.id,
-				permissions: newTokenScopes
+				permissions: newTokenScopes,
+				expires_on: newTokenExpiry || null
 			};
-			if (newTokenExpiresDays && Number(newTokenExpiresDays) > 0) {
-				const expires = new Date();
-				expires.setDate(expires.getDate() + Number(newTokenExpiresDays));
-				payload.expires_at = expires.toISOString();
-			}
 			const result = await api.createApiToken(payload);
 			mintedToken = result?.token || result?.api_token?.token || '';
 		} catch (err) {
@@ -798,8 +794,8 @@
 					<Input id="token-name" bind:value={newTokenName} required />
 				</div>
 				<div>
-					<Label for="token-expiry" color="default">Expires in (days, 0 = never)</Label>
-					<Input id="token-expiry" type="number" min="0" max="3650" bind:value={newTokenExpiresDays} />
+					<Label for="token-expiry" color="default">Last valid date (optional)</Label>
+					<Input id="token-expiry" type="date" bind:value={newTokenExpiry} />
 				</div>
 				{#if tokenTargetUser && !tokenTargetUser.agent_owner_user_id}
 					<AlertBox message="Service users do not inherit an owner's workspace/page permissions. Grant this agent workspace roles or page ACLs separately; scopes only limit what the token may do." />

--- a/frontend/src/lib/stores/securityStore.svelte.js
+++ b/frontend/src/lib/stores/securityStore.svelte.js
@@ -4,7 +4,6 @@
  * Centralizes credentials, tokens, SSH keys, and password management.
  */
 import { api } from '../api.js';
-import { dateInputToISOString } from '../utils/dateFormatter.js';
 import { capabilitiesStore } from './capabilities.svelte.js';
 
 class SecurityStore {
@@ -291,7 +290,7 @@ class SecurityStore {
       const tokenData = {
         name: this.newTokenName.trim(),
         permissions: this.newTokenScopes,
-        expires_at: dateInputToISOString(this.newTokenExpiry),
+        expires_on: this.newTokenExpiry || null,
       };
 
       const result = await api.createApiToken(tokenData);

--- a/internal/auth/tokens.go
+++ b/internal/auth/tokens.go
@@ -141,7 +141,7 @@ func (tm *TokenManager) ValidateToken(token string) (*models.User, *models.APITo
 			var entry tokenCacheEntry
 			if err := json.Unmarshal(data, &entry); err == nil {
 				switch {
-				case entry.ExpiresAt != nil && entry.ExpiresAt.Before(time.Now()):
+				case entry.ExpiresAt != nil && !time.Now().Before(*entry.ExpiresAt):
 					tm.cache.Delete(cacheKey) //nolint:errcheck // best-effort cache eviction
 				case !entry.User.IsActive:
 					tm.cache.Delete(cacheKey) //nolint:errcheck // best-effort cache eviction

--- a/internal/handlers/api_tokens.go
+++ b/internal/handlers/api_tokens.go
@@ -19,7 +19,7 @@ import (
 )
 
 // defaultAPITokenLifetime is the expiry applied to non-admin tokens that omit
-// expires_at. Caps the credential's lifetime so a forgotten token in CI logs
+// expires_on. Caps the credential's lifetime so a forgotten token in CI logs
 // or a stale dev machine eventually stops working without admin intervention.
 // Admins keep the never-expiring option for service tokens that need it.
 const defaultAPITokenLifetime = 90 * 24 * time.Hour
@@ -73,6 +73,25 @@ func (ath *APITokenHandler) CreateToken(w http.ResponseWriter, r *http.Request) 
 	if !ok {
 		return
 	}
+	if request.ExpiresAt != nil {
+		respondValidationError(w, r, "expires_at is not accepted; use expires_on in YYYY-MM-DD format")
+		return
+	}
+	if request.ExpiresOn != nil {
+		_, location, err := services.ResolveTimezone(user.Timezone)
+		if err != nil {
+			respondInternalError(w, r, err)
+			return
+		}
+		date, err := services.ParseCivilDate(*request.ExpiresOn, location)
+		if err != nil {
+			respondValidationError(w, r, "expires_on must use YYYY-MM-DD format")
+			return
+		}
+		// The token expires when the next day starts for the caller.
+		expiry := date.AddDate(0, 0, 1).UTC()
+		request.ExpiresAt = &expiry
+	}
 	sanitize.Apply(&request.Name, sanitize.PlainTextField)
 
 	// Validate required fields
@@ -111,7 +130,7 @@ func (ath *APITokenHandler) CreateToken(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Default expiry for non-admin callers when omitted. Admins can still mint
-	// never-expiring tokens by omitting expires_at — needed for some service
+	// never-expiring tokens by omitting expires_on — needed for some service
 	// integrations.
 	if request.ExpiresAt == nil {
 		isAdmin, _ := ath.permissionService.IsSystemAdmin(user.ID)

--- a/internal/models/common.go
+++ b/internal/models/common.go
@@ -1,11 +1,6 @@
 package models
 
-import (
-	"encoding/json"
-	"fmt"
-	"strings"
-	"time"
-)
+import "time"
 
 // APIWarning represents a non-fatal warning in an API response
 type APIWarning struct {
@@ -112,63 +107,11 @@ type APITokenCreate struct {
 	Name          string     `json:"name"`
 	UserID        *int       `json:"user_id,omitempty"` // Optional: admins can create tokens for other users
 	Permissions   []string   `json:"permissions"`
+	ExpiresOn     *string    `json:"expires_on,omitempty"`
 	ExpiresAt     *time.Time `json:"expires_at,omitempty"`
 	IsTemporary   bool       `json:"-"` // Internal-only: hide ephemeral server-minted tokens from user/admin token lists
 	OAuthClientID string     `json:"-"` // Internal-only: OAuth client that requested this token
 	OAuthResource string     `json:"-"` // Internal-only: RFC 8707 resource audience
-}
-
-// UnmarshalJSON accepts expires_at as either an RFC3339 timestamp or a bare
-// calendar date (YYYY-MM-DD). The token form's <input type="date"> submits a
-// bare date, which the default time.Time decoder rejects — failing the whole
-// request body with a 400 before any token logic runs. Parsing it here keeps
-// every APITokenCreate decode path (currently POST /api-tokens) tolerant of
-// both shapes without changing the field type the handler and store consume.
-func (r *APITokenCreate) UnmarshalJSON(data []byte) error {
-	// alias drops APITokenCreate's methods so the nested Unmarshal below does
-	// not recurse into this one; ExpiresAt is shadowed as raw JSON so a bare
-	// date does not trip the embedded time.Time decoder.
-	type alias APITokenCreate
-	aux := &struct {
-		ExpiresAt json.RawMessage `json:"expires_at"`
-		*alias
-	}{alias: (*alias)(r)}
-	if err := json.Unmarshal(data, aux); err != nil {
-		return err
-	}
-
-	r.ExpiresAt = nil
-	if len(aux.ExpiresAt) == 0 || string(aux.ExpiresAt) == "null" {
-		return nil
-	}
-	var raw string
-	if err := json.Unmarshal(aux.ExpiresAt, &raw); err != nil {
-		return fmt.Errorf("expires_at must be a string date or RFC3339 timestamp: %w", err)
-	}
-	if strings.TrimSpace(raw) == "" {
-		return nil
-	}
-	expiry, err := parseTokenExpiry(raw)
-	if err != nil {
-		return err
-	}
-	r.ExpiresAt = &expiry
-	return nil
-}
-
-// parseTokenExpiry accepts an RFC3339 timestamp or a bare calendar date. A bare
-// date is interpreted as the end of that day in UTC (23:59:59) so a token
-// created to expire "today" stays valid through the day rather than expiring at
-// midnight — otherwise the input's min=today would mint an already-expired token.
-func parseTokenExpiry(raw string) (time.Time, error) {
-	raw = strings.TrimSpace(raw)
-	if t, err := time.Parse(time.RFC3339, raw); err == nil {
-		return t, nil
-	}
-	if d, err := time.Parse("2006-01-02", raw); err == nil {
-		return time.Date(d.Year(), d.Month(), d.Day(), 23, 59, 59, 0, time.UTC), nil
-	}
-	return time.Time{}, fmt.Errorf("invalid expires_at %q: want RFC3339 (2006-01-02T15:04:05Z) or a date (2006-01-02)", raw)
 }
 
 // APITokenResponse represents the response when creating an API token

--- a/internal/models/common.go
+++ b/internal/models/common.go
@@ -1,6 +1,11 @@
 package models
 
-import "time"
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
 
 // APIWarning represents a non-fatal warning in an API response
 type APIWarning struct {
@@ -111,6 +116,59 @@ type APITokenCreate struct {
 	IsTemporary   bool       `json:"-"` // Internal-only: hide ephemeral server-minted tokens from user/admin token lists
 	OAuthClientID string     `json:"-"` // Internal-only: OAuth client that requested this token
 	OAuthResource string     `json:"-"` // Internal-only: RFC 8707 resource audience
+}
+
+// UnmarshalJSON accepts expires_at as either an RFC3339 timestamp or a bare
+// calendar date (YYYY-MM-DD). The token form's <input type="date"> submits a
+// bare date, which the default time.Time decoder rejects — failing the whole
+// request body with a 400 before any token logic runs. Parsing it here keeps
+// every APITokenCreate decode path (currently POST /api-tokens) tolerant of
+// both shapes without changing the field type the handler and store consume.
+func (r *APITokenCreate) UnmarshalJSON(data []byte) error {
+	// alias drops APITokenCreate's methods so the nested Unmarshal below does
+	// not recurse into this one; ExpiresAt is shadowed as raw JSON so a bare
+	// date does not trip the embedded time.Time decoder.
+	type alias APITokenCreate
+	aux := &struct {
+		ExpiresAt json.RawMessage `json:"expires_at"`
+		*alias
+	}{alias: (*alias)(r)}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	r.ExpiresAt = nil
+	if len(aux.ExpiresAt) == 0 || string(aux.ExpiresAt) == "null" {
+		return nil
+	}
+	var raw string
+	if err := json.Unmarshal(aux.ExpiresAt, &raw); err != nil {
+		return fmt.Errorf("expires_at must be a string date or RFC3339 timestamp: %w", err)
+	}
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	expiry, err := parseTokenExpiry(raw)
+	if err != nil {
+		return err
+	}
+	r.ExpiresAt = &expiry
+	return nil
+}
+
+// parseTokenExpiry accepts an RFC3339 timestamp or a bare calendar date. A bare
+// date is interpreted as the end of that day in UTC (23:59:59) so a token
+// created to expire "today" stays valid through the day rather than expiring at
+// midnight — otherwise the input's min=today would mint an already-expired token.
+func parseTokenExpiry(raw string) (time.Time, error) {
+	raw = strings.TrimSpace(raw)
+	if t, err := time.Parse(time.RFC3339, raw); err == nil {
+		return t, nil
+	}
+	if d, err := time.Parse("2006-01-02", raw); err == nil {
+		return time.Date(d.Year(), d.Month(), d.Day(), 23, 59, 59, 0, time.UTC), nil
+	}
+	return time.Time{}, fmt.Errorf("invalid expires_at %q: want RFC3339 (2006-01-02T15:04:05Z) or a date (2006-01-02)", raw)
 }
 
 // APITokenResponse represents the response when creating an API token


### PR DESCRIPTION
## Summary

- accept API token expiry as `expires_on`: a `YYYY-MM-DD` calendar date or `null`
- interpret the date in the authenticated caller's configured IANA timezone and store the start of the following local day as UTC
- use the same date-only contract across the security, profile-agent, and administrator token forms
- reject blank dates, malformed dates, timestamps, and the old `expires_at` request field

## Tests

- HTTP contract coverage for UTC, Europe/Zurich across a DST boundary, null, invalid input, and the retired field
- frontend store coverage for date and null payloads
- Playwright coverage for the token creation form payload
