### PR TITLE
feat(auth): make session IP binding configurable (SESSION_IP_BINDING log|strict|off)

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -16,6 +16,13 @@ DOMAIN=windshift.example.com
 # Generate manually with: openssl rand -hex 32
 SSO_SECRET=
 
+# How a session presented from a different client IP than it was created from
+# is handled (default: log). One of: log, strict, off.
+#   log    - record the mismatch and serve the request anyway
+#   strict - reject the session, forcing re-authentication
+#   off    - do not compare client IPs at all
+# SESSION_IP_BINDING=log
+
 # =============================================================================
 # PostgreSQL Settings (uncomment when using PostgreSQL instead of SQLite)
 # =============================================================================

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -18,7 +18,9 @@ SSO_SECRET=
 
 # How a session presented from a different client IP than it was created from
 # is handled (default: log). One of: log, strict, off.
-#   log    - record the mismatch and serve the request anyway
+#   log    - record the mismatch, serve the request, and remember the new IP
+#            as the session's binding (a parseable IP only; garbage is never
+#            persisted)
 #   strict - reject the session, forcing re-authentication
 #   off    - do not compare client IPs at all
 # SESSION_IP_BINDING=log

--- a/deploy/docker-compose-main.yml
+++ b/deploy/docker-compose-main.yml
@@ -23,6 +23,7 @@ services:
       - PORT=8080
       - USE_PROXY=true
       - SSO_SECRET=${SSO_SECRET}
+      - SESSION_IP_BINDING=${SESSION_IP_BINDING:-log}
       - ATTACHMENT_PATH=/data/attachments
       - DB_TYPE=postgres
       - POSTGRES_HOST=db

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - PORT=8080
       - USE_PROXY=true
       - SSO_SECRET=${SSO_SECRET}
+      - SESSION_IP_BINDING=${SESSION_IP_BINDING:-log}
       - ATTACHMENT_PATH=/data/attachments
       - DB_PATH=/data/windshift.db
       - LOG_LEVEL=info

--- a/internal/auth/portal_session.go
+++ b/internal/auth/portal_session.go
@@ -176,26 +176,45 @@ func (sm *PortalSessionManager) ValidatePortalSession(token, ipAddress string) (
 	}
 
 	// Validate IP address for security. Portal sessions store the client IP at
-	// creation; subsequent validations must match the same binding used by
-	// internal user sessions. Legacy rows with no recorded IP are accepted but
-	// logged so operators can investigate. Missing request IP or mismatch fails
-	// closed.
-	switch {
-	case session.IPAddress == "":
+	// creation; subsequent validations apply the same SESSION_IP_BINDING mode
+	// as internal user sessions. Legacy rows with no recorded IP are accepted
+	// but logged so operators can investigate. Under strict a missing request
+	// IP or a mismatch fails closed; under log the session is followed to its
+	// new IP; under off no comparison happens. No mode deactivates the session.
+	switch decideIPBinding(sm.ipBinding, session.IPAddress, ipAddress) {
+	case ipBindingLegacyUnbound:
 		slog.Warn("portal session has no recorded IP, skipping bind check",
 			slog.Int("portal_customer_id", session.PortalCustomerID),
 			slog.Int("session_id", session.ID))
-	case ipAddress == "":
+	case ipBindingRejectNoRequestIP:
 		slog.Warn("request has no client IP, rejecting IP-bound portal session",
 			slog.Int("portal_customer_id", session.PortalCustomerID),
 			slog.String("session_ip", session.IPAddress))
 		return nil, ErrPortalSessionInvalid
-	case session.IPAddress != ipAddress:
+	case ipBindingAcceptNoRequestIP:
+		slog.Warn("request has no client IP, accepting IP-bound portal session",
+			slog.Int("portal_customer_id", session.PortalCustomerID),
+			slog.String("session_ip", session.IPAddress),
+			slog.String("session_ip_binding", sm.ipBinding))
+	case ipBindingAcceptUnparsedIP:
+		slog.Warn("request client IP is not a valid address, accepting IP-bound portal session without rebinding",
+			slog.Int("portal_customer_id", session.PortalCustomerID),
+			slog.String("session_ip", session.IPAddress),
+			slog.String("request_ip", ipAddress),
+			slog.String("session_ip_binding", sm.ipBinding))
+	case ipBindingRejectMismatch:
 		slog.Warn("portal session IP mismatch",
 			slog.Int("portal_customer_id", session.PortalCustomerID),
 			slog.String("session_ip", session.IPAddress),
 			slog.String("request_ip", ipAddress))
 		return nil, ErrPortalSessionInvalid
+	case ipBindingRebindMismatch:
+		slog.Warn("portal session IP mismatch",
+			slog.Int("portal_customer_id", session.PortalCustomerID),
+			slog.String("session_ip", session.IPAddress),
+			slog.String("request_ip", ipAddress))
+		sm.rebindPortalSessionIP(token, session, ipAddress)
+	case ipBindingMatch, ipBindingSkip:
 	}
 
 	if channelID.Valid {
@@ -214,6 +233,27 @@ func (sm *PortalSessionManager) ValidatePortalSession(token, ipAddress string) (
 	}
 
 	return session, nil
+}
+
+// rebindPortalSessionIP moves a portal session to the client IP it is now
+// presented from (log mode only). Like the user-session rebind, a failed write
+// costs bookkeeping rather than availability: the request is still served and
+// the next one retries. Portal sessions have no local validation cache, so
+// nothing needs invalidating; the in-memory session is advanced on success
+// because it is returned to the caller.
+func (sm *PortalSessionManager) rebindPortalSessionIP(token string, session *PortalSession, ipAddress string) {
+	// Portal tokens are stored as digests with the same legacy plaintext
+	// fallback as user sessions, so the predicate must match both forms.
+	query := `UPDATE portal_customer_sessions SET ip_address = ? WHERE session_token IN (?, ?) AND is_active = true`
+	if _, err := sm.db.ExecWrite(query, ipAddress, hashSessionToken(token), token); err != nil {
+		slog.Error("failed to rebind portal session to the new client IP",
+			slog.Int("portal_customer_id", session.PortalCustomerID),
+			slog.Int("session_id", session.ID),
+			slog.String("request_ip", ipAddress),
+			slog.Any("error", err))
+		return
+	}
+	session.IPAddress = ipAddress
 }
 
 // DeletePortalSession invalidates a session

--- a/internal/auth/portal_session.go
+++ b/internal/auth/portal_session.go
@@ -57,17 +57,24 @@ type PortalSession struct {
 type PortalSessionManager struct {
 	cookieManager
 	db database.Database
+	// ipBinding is the resolved SESSION_IP_BINDING mode (config.SessionIPBinding*)
+	// that portal session validation applies to a client-IP change. Wired but
+	// not yet consulted; ValidatePortalSession still behaves as before.
+	ipBinding string
 }
 
 // NewPortalSessionManager creates a new portal session manager with secure cookie handling.
 // If cookieSecret is set, deterministic cookie keys are derived from it
 // so that sessions survive process restarts with the same secret.
+// ipBinding is the resolved SESSION_IP_BINDING mode; portal sessions share the
+// setting with internal user sessions because they enforce the same binding.
 // last review: ser, 210426, NOTE: Found hardcoded env var in caller
-func NewPortalSessionManager(db database.Database, useSecureCookies, useProxy bool, additionalProxies []string, cookieSecret string) *PortalSessionManager {
+func NewPortalSessionManager(db database.Database, useSecureCookies, useProxy bool, additionalProxies []string, cookieSecret, ipBinding string) *PortalSessionManager {
 	return &PortalSessionManager{
 		cookieManager: newCookieManager(useSecureCookies, useProxy, additionalProxies, cookieSecret,
 			"windshift-portal-cookie-hash", "windshift-portal-cookie-block"),
-		db: db,
+		db:        db,
+		ipBinding: ipBinding,
 	}
 }
 

--- a/internal/auth/portal_session.go
+++ b/internal/auth/portal_session.go
@@ -58,8 +58,9 @@ type PortalSessionManager struct {
 	cookieManager
 	db database.Database
 	// ipBinding is the resolved SESSION_IP_BINDING mode (config.SessionIPBinding*)
-	// that portal session validation applies to a client-IP change. Wired but
-	// not yet consulted; ValidatePortalSession still behaves as before.
+	// that portal session validation applies to a client-IP change. An unknown
+	// or zero value is treated as strict so managers built without config.Load
+	// fail closed.
 	ipBinding string
 }
 

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -55,8 +55,9 @@ type SessionManager struct {
 	opaqueKey         []byte
 	sessionValidation *sessionValidator
 	// ipBinding is the resolved SESSION_IP_BINDING mode (config.SessionIPBinding*)
-	// that session validation applies to a client-IP change. Wired but not yet
-	// consulted; validation still behaves as before.
+	// that session validation applies to a client-IP change. An unknown or
+	// zero value is treated as strict so managers built without config.Load
+	// fail closed.
 	ipBinding string
 }
 

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -54,6 +54,10 @@ type SessionManager struct {
 	db                database.Database
 	opaqueKey         []byte
 	sessionValidation *sessionValidator
+	// ipBinding is the resolved SESSION_IP_BINDING mode (config.SessionIPBinding*)
+	// that session validation applies to a client-IP change. Wired but not yet
+	// consulted; validation still behaves as before.
+	ipBinding string
 }
 
 // Session represents an active user session
@@ -74,14 +78,16 @@ type Session struct {
 // NewSessionManager creates a new session manager with secure cookie handling.
 // If cookieSecret is non-empty, deterministic cookie keys are derived from it
 // so that sessions survive process restarts with the same secret.
+// ipBinding is the resolved SESSION_IP_BINDING mode.
 // last review: ser, 210426
-func NewSessionManager(db database.Database, useSecureCookies, useProxy bool, additionalProxies []string, cookieSecret string) *SessionManager {
+func NewSessionManager(db database.Database, useSecureCookies, useProxy bool, additionalProxies []string, cookieSecret, ipBinding string) *SessionManager {
 	return NewSessionManagerWithValidationCacheTTL(
 		db,
 		useSecureCookies,
 		useProxy,
 		additionalProxies,
 		cookieSecret,
+		ipBinding,
 		DefaultSessionValidationCacheTTL,
 	)
 }
@@ -89,13 +95,14 @@ func NewSessionManager(db database.Database, useSecureCookies, useProxy bool, ad
 // NewSessionManagerWithValidationCacheTTL creates a session manager with a
 // bounded local validation cache. A non-positive TTL disables retained cache
 // entries while preserving in-flight request coalescing.
-func NewSessionManagerWithValidationCacheTTL(db database.Database, useSecureCookies, useProxy bool, additionalProxies []string, cookieSecret string, validationCacheTTL time.Duration, cacheSizeMB ...int) *SessionManager {
+func NewSessionManagerWithValidationCacheTTL(db database.Database, useSecureCookies, useProxy bool, additionalProxies []string, cookieSecret, ipBinding string, validationCacheTTL time.Duration, cacheSizeMB ...int) *SessionManager {
 	return newSessionManagerWithValidationCache(
 		db,
 		useSecureCookies,
 		useProxy,
 		additionalProxies,
 		cookieSecret,
+		ipBinding,
 		validationCacheTTL,
 		"session_validation",
 		cacheSizeMB...,
@@ -105,20 +112,21 @@ func NewSessionManagerWithValidationCacheTTL(db database.Database, useSecureCook
 // NewSessionManagerWithNamedValidationCacheTTL creates a session manager whose
 // validation cache has an explicit diagnostics name. The SSH server uses it so
 // the HTTP and SSH allocations remain independently visible.
-func NewSessionManagerWithNamedValidationCacheTTL(db database.Database, useSecureCookies, useProxy bool, additionalProxies []string, cookieSecret string, validationCacheTTL time.Duration, cacheName string, cacheSizeMB int) *SessionManager {
+func NewSessionManagerWithNamedValidationCacheTTL(db database.Database, useSecureCookies, useProxy bool, additionalProxies []string, cookieSecret, ipBinding string, validationCacheTTL time.Duration, cacheName string, cacheSizeMB int) *SessionManager {
 	return newSessionManagerWithValidationCache(
 		db,
 		useSecureCookies,
 		useProxy,
 		additionalProxies,
 		cookieSecret,
+		ipBinding,
 		validationCacheTTL,
 		cacheName,
 		cacheSizeMB,
 	)
 }
 
-func newSessionManagerWithValidationCache(db database.Database, useSecureCookies, useProxy bool, additionalProxies []string, cookieSecret string, validationCacheTTL time.Duration, cacheName string, cacheSizeMB ...int) *SessionManager {
+func newSessionManagerWithValidationCache(db database.Database, useSecureCookies, useProxy bool, additionalProxies []string, cookieSecret, ipBinding string, validationCacheTTL time.Duration, cacheName string, cacheSizeMB ...int) *SessionManager {
 	var opaqueKey []byte
 	if cookieSecret != "" {
 		opaqueKey = deriveKey(cookieSecret, "windshift-auth-opaque-values", 32)
@@ -131,6 +139,7 @@ func newSessionManagerWithValidationCache(db database.Database, useSecureCookies
 		db:                db,
 		opaqueKey:         opaqueKey,
 		sessionValidation: newSessionValidator(validationCacheTTL, cacheName, cacheSizeMB...),
+		ipBinding:         ipBinding,
 	}
 }
 

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -264,6 +264,23 @@ func (sm *SessionManager) RefreshSession(token string, rememberMe bool) error {
 	return nil
 }
 
+// UpdateSessionIP rebinds a session to a new client IP. It is used by the log
+// SESSION_IP_BINDING mode, where a session that moves between networks is
+// followed rather than rejected. Sessions are stored as token digests with a
+// legacy plaintext fallback, so the predicate matches both forms — a
+// plaintext-only predicate would match zero rows for every current session.
+func (sm *SessionManager) UpdateSessionIP(token, ipAddress string) error {
+	query := `UPDATE user_sessions SET ip_address = ? WHERE session_token IN (?, ?) AND is_active = true`
+	_, err := sm.db.ExecWrite(query, ipAddress, hashSessionToken(token), token)
+	if err != nil {
+		return fmt.Errorf("failed to update session IP: %w", err)
+	}
+	// The cached snapshot still carries the previous IP; drop it so the next
+	// request revalidates against the rebound row instead of rebinding again.
+	sm.invalidateSessionValidationToken(token)
+	return nil
+}
+
 // SetSessionCookie sets a secure session cookie
 func (sm *SessionManager) SetSessionCookie(w http.ResponseWriter, r *http.Request, token string, rememberMe bool) error {
 	maxAge := int(DefaultSessionDuration.Seconds())

--- a/internal/auth/session_validation.go
+++ b/internal/auth/session_validation.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"golang.org/x/sync/singleflight"
 
 	"windshift/internal/cacheutil"
+	"windshift/internal/config"
 	"windshift/internal/models"
 )
 
@@ -290,6 +292,68 @@ func validateSessionState(session *Session) error {
 	return nil
 }
 
+// ipBindingDecision is what a validator should do about the request's client
+// IP. The decision is shared by the user-session and portal validators; each
+// keeps its own log wording and error value.
+type ipBindingDecision int
+
+const (
+	// ipBindingMatch: the request IP equals the bound IP — nothing to do.
+	ipBindingMatch ipBindingDecision = iota
+	// ipBindingSkip: binding disabled; no comparison and no log line.
+	ipBindingSkip
+	// ipBindingLegacyUnbound: the session predates IP binding (no stored IP).
+	ipBindingLegacyUnbound
+	// ipBindingRejectNoRequestIP: bound session, no client IP, fail closed.
+	ipBindingRejectNoRequestIP
+	// ipBindingAcceptNoRequestIP: same situation, reported but served.
+	ipBindingAcceptNoRequestIP
+	// ipBindingAcceptUnparsedIP: the request carries an IP that is not a valid
+	// address, so there is nothing safe to rebind to; reported but served.
+	ipBindingAcceptUnparsedIP
+	// ipBindingRejectMismatch: the session moved to another IP, fail closed.
+	ipBindingRejectMismatch
+	// ipBindingRebindMismatch: the session moved; rebind it and serve.
+	ipBindingRebindMismatch
+)
+
+// decideIPBinding maps a SESSION_IP_BINDING mode plus the stored/request IP
+// pair onto one decision.
+//
+// Any mode other than log or off is treated as strict, so a manager built
+// outside config.Load (which validates the env var) keeps the historical
+// fail-closed behavior rather than silently loosening it.
+func decideIPBinding(mode, sessionIP, requestIP string) ipBindingDecision {
+	if mode == config.SessionIPBindingOff {
+		return ipBindingSkip
+	}
+	lenient := mode == config.SessionIPBindingLog
+
+	switch {
+	case sessionIP == "":
+		return ipBindingLegacyUnbound
+	case requestIP == "":
+		if lenient {
+			return ipBindingAcceptNoRequestIP
+		}
+		return ipBindingRejectNoRequestIP
+	case sessionIP != requestIP:
+		if lenient {
+			// Only a real address may be written back to the session row. The
+			// client-IP extractor returns RemoteAddr verbatim when it does not
+			// parse (utils.IPExtractor.GetClientIP), and these validators are
+			// exported, so an unparseable value must be reported and served
+			// rather than persisted as the session's new binding.
+			if net.ParseIP(requestIP) == nil {
+				return ipBindingAcceptUnparsedIP
+			}
+			return ipBindingRebindMismatch
+		}
+		return ipBindingRejectMismatch
+	}
+	return ipBindingMatch
+}
+
 func (sm *SessionManager) validateSessionSnapshot(token string, session *Session, ipAddress string) (*Session, error) {
 	if err := validateSessionState(session); err != nil {
 		if errors.Is(err, ErrSessionExpired) {
@@ -298,27 +362,72 @@ func (sm *SessionManager) validateSessionSnapshot(token string, session *Session
 		return nil, err
 	}
 
-	// The IP check is deliberately performed for every request, including
-	// cache hits. Empty stored IPs remain accepted for legacy sessions; an
-	// empty request IP fails closed for sessions that are bound to an IP.
-	switch {
-	case session.IPAddress == "":
+	if err := sm.applySessionIPBinding(token, session, ipAddress); err != nil {
+		return nil, err
+	}
+	return session, nil
+}
+
+// applySessionIPBinding enforces the configured SESSION_IP_BINDING mode. The
+// check is deliberately performed for every request, including cache hits.
+// Empty stored IPs remain accepted for legacy sessions; under strict an empty
+// request IP fails closed for sessions that are bound to an IP, while log
+// reports the same situations and serves them. No mode deletes or deactivates
+// the session: a rejection fails this request only.
+func (sm *SessionManager) applySessionIPBinding(token string, session *Session, ipAddress string) error {
+	switch decideIPBinding(sm.ipBinding, session.IPAddress, ipAddress) {
+	case ipBindingLegacyUnbound:
 		slog.Warn("session has no recorded IP, skipping bind check",
 			slog.Int("user_id", session.UserID),
 			slog.Int("session_id", session.ID))
-	case ipAddress == "":
+	case ipBindingRejectNoRequestIP:
 		slog.Warn("request has no client IP, rejecting IP-bound session",
 			slog.Int("user_id", session.UserID),
 			slog.String("session_ip", session.IPAddress))
-		return nil, ErrInvalidSession
-	case session.IPAddress != ipAddress:
+		return ErrInvalidSession
+	case ipBindingAcceptNoRequestIP:
+		slog.Warn("request has no client IP, accepting IP-bound session",
+			slog.Int("user_id", session.UserID),
+			slog.String("session_ip", session.IPAddress),
+			slog.String("session_ip_binding", sm.ipBinding))
+	case ipBindingAcceptUnparsedIP:
+		slog.Warn("request client IP is not a valid address, accepting IP-bound session without rebinding",
+			slog.Int("user_id", session.UserID),
+			slog.String("session_ip", session.IPAddress),
+			slog.String("request_ip", ipAddress),
+			slog.String("session_ip_binding", sm.ipBinding))
+	case ipBindingRejectMismatch:
 		slog.Warn("session IP mismatch",
 			slog.Int("user_id", session.UserID),
 			slog.String("session_ip", session.IPAddress),
 			slog.String("request_ip", ipAddress))
-		return nil, ErrInvalidSession
+		return ErrInvalidSession
+	case ipBindingRebindMismatch:
+		slog.Warn("session IP mismatch",
+			slog.Int("user_id", session.UserID),
+			slog.String("session_ip", session.IPAddress),
+			slog.String("request_ip", ipAddress))
+		sm.rebindSessionIP(token, session, ipAddress)
+	case ipBindingMatch, ipBindingSkip:
 	}
-	return session, nil
+	return nil
+}
+
+// rebindSessionIP moves a session to the client IP it is now presented from.
+// A failed write costs bookkeeping, not availability: the request is still
+// served and the next one retries the rebind. The in-memory snapshot is
+// advanced only on success, because it is what the triggering request reports
+// back through /api/auth/me.
+func (sm *SessionManager) rebindSessionIP(token string, session *Session, ipAddress string) {
+	if err := sm.UpdateSessionIP(token, ipAddress); err != nil {
+		slog.Error("failed to rebind session to the new client IP",
+			slog.Int("user_id", session.UserID),
+			slog.Int("session_id", session.ID),
+			slog.String("request_ip", ipAddress),
+			slog.Any("error", err))
+		return
+	}
+	session.IPAddress = ipAddress
 }
 
 func (validator *sessionValidator) get(key string) (*Session, bool) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -104,6 +104,25 @@ type SSHConfig struct {
 	KeyPath string
 }
 
+// Session IP-binding modes, resolved from SESSION_IP_BINDING into
+// AuthConfig.SessionIPBinding. Deployments behind a load balancer with a
+// changing egress IP, or with mobile clients that roam between networks, need
+// a weaker binding than one serving a fixed office range.
+const (
+	// SessionIPBindingLog records a client-IP change on a session and serves
+	// the request anyway. It is the default so the mismatch rate is observable
+	// before an operator switches to strict.
+	SessionIPBindingLog = "log"
+	// SessionIPBindingStrict rejects a session presented from a client IP
+	// other than the one it was created from.
+	SessionIPBindingStrict = "strict"
+	// SessionIPBindingOff skips the client-IP comparison entirely.
+	SessionIPBindingOff = "off"
+
+	// DefaultSessionIPBinding applies when SESSION_IP_BINDING is unset or empty.
+	DefaultSessionIPBinding = SessionIPBindingLog
+)
+
 // AuthConfig holds session-signing / SSO credential-encryption secrets.
 type AuthConfig struct {
 	// SessionSecret is resolved from SSO_SECRET (preferred) with fallback to
@@ -113,6 +132,11 @@ type AuthConfig struct {
 	// SessionValidationCacheTTL bounds local session/user-state staleness. Zero
 	// disables retained validation entries; the default is five seconds.
 	SessionValidationCacheTTL time.Duration
+	// SessionIPBinding selects how a client-IP change on an existing session is
+	// handled: SessionIPBindingLog, SessionIPBindingStrict or
+	// SessionIPBindingOff. Load validates it, so consumers can treat any other
+	// value as unreachable.
+	SessionIPBinding string
 }
 
 // WebAuthnConfig holds WebAuthn relying-party identity.

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -3,6 +3,7 @@ package config
 import (
 	"embed"
 	"flag"
+	"fmt"
 	"log/slog"
 	"net/url"
 	"os"
@@ -163,6 +164,16 @@ func Load(frontend embed.FS, shutdownChan chan os.Signal) Config {
 		os.Exit(1)
 	}
 
+	// Session IP binding: validated here so a typo fails at startup rather than
+	// silently weakening (or hardening) session validation at runtime.
+	rawSessionIPBinding := os.Getenv("SESSION_IP_BINDING")
+	resolvedSessionIPBinding, sessionIPBindingErr := resolveSessionIPBinding(rawSessionIPBinding)
+	if sessionIPBindingErr != nil {
+		slog.Error("FATAL: invalid SESSION_IP_BINDING",
+			"session_ip_binding", rawSessionIPBinding, "error", sessionIPBindingErr)
+		os.Exit(1)
+	}
+
 	// WebAuthn: use the browser-visible BASE_URL hostname by default. This is
 	// especially important in containers, where os.Hostname() is normally an
 	// internal container ID that browsers can never use as a relying-party ID.
@@ -225,6 +236,7 @@ func Load(frontend embed.FS, shutdownChan chan os.Signal) Config {
 		Auth: AuthConfig{
 			SessionSecret:             sessionSecret,
 			SessionValidationCacheTTL: parseDurationEnv("SESSION_VALIDATION_CACHE_TTL", 5*time.Second),
+			SessionIPBinding:          resolvedSessionIPBinding,
 		},
 		WebAuthn: WebAuthnConfig{
 			RPID:   rpID,
@@ -352,6 +364,25 @@ func postgresSSLMode() string {
 		"sslmode", raw)
 	os.Exit(1)
 	return ""
+}
+
+// resolveSessionIPBinding validates SESSION_IP_BINDING and returns the mode to
+// store in AuthConfig. It is pure — the os.Exit for an invalid value stays in
+// Load — so the accepted/rejected sets are testable without a fatal path.
+//
+// Empty (unset, or whitespace only) resolves to DefaultSessionIPBinding rather
+// than failing: the variable is optional.
+func resolveSessionIPBinding(raw string) (string, error) {
+	mode := strings.ToLower(strings.TrimSpace(raw))
+	if mode == "" {
+		return DefaultSessionIPBinding, nil
+	}
+	switch mode {
+	case SessionIPBindingLog, SessionIPBindingStrict, SessionIPBindingOff:
+		return mode, nil
+	}
+	return "", fmt.Errorf("SESSION_IP_BINDING must be one of %s, %s, %s; got %q",
+		SessionIPBindingLog, SessionIPBindingStrict, SessionIPBindingOff, raw)
 }
 
 func normalizeContextPath(raw string) string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -275,6 +275,7 @@ func (s *Server) initialize() error {
 		cfg.UseProxy,
 		additionalProxyList,
 		cfg.Auth.SessionSecret,
+		cfg.Auth.SessionIPBinding,
 		cfg.Auth.SessionValidationCacheTTL,
 		primarySessionCacheMB,
 	)
@@ -443,7 +444,7 @@ func (s *Server) initialize() error {
 
 	emailVerificationService := services.NewEmailVerificationService(s.db, smtpSender, baseURL)
 
-	portalSessionManager := auth.NewPortalSessionManager(s.db, enableHTTPS, cfg.UseProxy, additionalProxyList, cfg.Auth.SessionSecret)
+	portalSessionManager := auth.NewPortalSessionManager(s.db, enableHTTPS, cfg.UseProxy, additionalProxyList, cfg.Auth.SessionSecret, cfg.Auth.SessionIPBinding)
 
 	magicLinkService := services.NewMagicLinkService(s.db, smtpSender, baseURL)
 

--- a/main.go
+++ b/main.go
@@ -166,6 +166,7 @@ func main() {
 				cfg.UseProxy,
 				additionalProxyList,
 				cfg.Auth.SessionSecret,
+				cfg.Auth.SessionIPBinding,
 				cfg.Auth.SessionValidationCacheTTL,
 				"ssh_session_validation",
 				sshSessionCacheMB,


### PR DESCRIPTION

## Problem

Sessions are hard-bound to the client IP recorded at login: any request from a different IP is rejected with `ErrInvalidSession` on every request (`internal/auth/session_validation.go`, tightened to fail-closed in `dcbf5a3a`), and the stored IP is never updated. In practice this signs users out on every LAN interface switch, DHCP renewal, ISP address rotation (daily for many European residential connections), VPN toggle, or mobile handoff — defeating the "Keep me signed in to Windshift for 30 days" option. On my production instance the log pattern was 12× `session IP mismatch` warnings, each followed within seconds by a forced OIDC re-login, from a single user whose LAN address oscillated between two interfaces.

Two design observations reinforced treating this as a bug rather than a hardening feature:

- `crw_*` API bearer tokens carry no IP binding at all, so the strict browser-session check doesn't establish a consistent security boundary.
- No security standard requires it: OWASP's Session Management Cheat Sheet treats IP binding as a supplementary *detection* signal that "cannot be used ... to trustingly defend against session attacks" (naming NAT/proxy shared IPs as the false-positive mode); ASVS has no session-management IP requirement at any level; NIST 800-63B binds sessions purely to possession of the session secret. Surveyed practice matches: no mainstream framework (Django, Rails, Spring Security, ASP.NET) or comparable IdP (Keycloak, Ory Kratos, Authelia — which declined exactly this feature in authelia/authelia#4345) binds sessions to IP by default; where it exists it is opt-in and deliberately coarse (phpBB's partial-octet `ip_check`, Authentik's GeoIP/ASN stage).

## Change

New env `SESSION_IP_BINDING` (validated at startup, fatal on invalid values, following the `POSTGRES_SSLMODE` pattern):

- **`log` (new default):** a valid session presented from a new client IP is accepted; one structured `session IP mismatch` warning is emitted per move; the stored `ip_address` is rebound to the new IP (so the audit trail stays current and the warning fires once per move, not per request) and the session-validation cache entry is invalidated. The accepted snapshot carries the new IP, so the triggering request already serves consistent data.
- **`strict`:** the previous behavior, byte-for-byte — same messages/attributes, same errors, fail-closed on a missing client IP, legacy sessions with no stored IP still accepted.
- **`off`:** no IP comparison, no IP log lines.

Details that came out of review:

- Rebind uses the same dual-form token predicate as the existing session UPDATEs (`WHERE session_token IN (hash, plaintext)`), since sessions are stored hashed with a legacy plaintext fallback.
- Rebind only persists a **parseable** IP (`net.ParseIP`): the client-IP extractor's malformed-`RemoteAddr` fallback returns unparsed text, which must never end up in `user_sessions.ip_address`. Unparseable input is warned and accepted without rebinding.
- A rebind write failure logs an error and still accepts the request (availability over bookkeeping; the next request retries).
- Portal sessions (`ValidatePortalSession`) honor the same mode with the same semantics against `portal_customer_sessions` (their tokens are hashed the same way; no validation cache there, so no invalidation call).
- An unknown or zero-value mode at the manager level falls back to **strict**, so a `SessionManager` constructed without `config.Load` (e.g. in tests) fails closed rather than silently loosening.
- `deploy/docker-compose.yml`, `deploy/docker-compose-main.yml` and `deploy/.env.example` pass the variable through / document it.

**On the default:** I propose `log` as the default because the strict behavior breaks roaming clients by design and no surveyed standard or peer product defaults to it — but if you prefer zero behavior change for existing deployments, flipping the default back to `strict` is a one-line change in `internal/config/load.go` and I'm happy to do so.

## Testing

Test sources live in the private core-tests repo I can't access, so this PR ships with a written test plan (implemented and run locally as table-driven Go tests, 56 PASS / 0 FAIL, plus mutation checks on the mode switch, the cache invalidation, and the ParseIP guard):

- Matrix {log, strict, off} × {IP match, IP mismatch, empty request IP, empty stored IP, unparseable request IP} for both the user-session and portal validators — asserting accept/reject, warning presence/absence, and rebind occurrence.
- Rebind persistence: after a log-mode mismatch, the row holds the new IP and a repeat request from that IP emits no second warning (this fails if cache invalidation is dropped).
- Rebind failure path: the request is still accepted.
- Strict-mode rows were pinned green against the pre-change code first, proving byte-for-byte preservation.

Live verification on my production instance (v0.8.5 fork build, `SESSION_IP_BINDING=log`): replaying a valid session against the container with `X-Forwarded-For` `192.168.1.11` → HTTP 200 + one warning + row rebound; repeat → 200, silent; `X-Forwarded-For` `192.168.1.33` → 200 + one warning (whose logged `session_ip=192.168.1.11` proves the first rebind persisted) + row rebound; repeat → silent. Under the current code every one of those requests is a 401 forced re-login.

## Noticed while working on this (out of scope, can file separately)

- `ClearEnrollmentRequired`/`ClearEnrollmentRequiredByUserID` reset `expires_at` to the 24h default after passkey verification/enrollment, silently discarding a remember-me session's 30-day duration (there's no `remember_me` column to recall it from).
- `POST /auth/refresh` exists but has no frontend callers, so session TTLs never slide.
- Possible follow-up to this PR: subnet/ASN-granular binding as a fourth mode, for operators who want tolerance without full logging-only.
