### PR TITLE
fix(frontend): restore markdown list markers

### DIFF
--- a/frontend/src/lib/components/SafeMarkdown.svelte
+++ b/frontend/src/lib/components/SafeMarkdown.svelte
@@ -60,6 +60,19 @@
     padding-inline-start: 1.5rem;
   }
 
+  .safe-markdown :global(ul) {
+    list-style-type: disc;
+  }
+
+  .safe-markdown :global(ol) {
+    list-style-type: decimal;
+  }
+
+  .safe-markdown :global(li) {
+    display: list-item;
+    margin-block: 0.25em;
+  }
+
   .safe-markdown :global(a) {
     color: var(--ds-text-link);
     text-decoration: underline;

--- a/frontend/src/lib/components/SafeMarkdown.svelte
+++ b/frontend/src/lib/components/SafeMarkdown.svelte
@@ -73,6 +73,11 @@
     margin-block: 0.25em;
   }
 
+  .safe-markdown :global(li:has(> input[type='checkbox']:first-child)),
+  .safe-markdown :global(li:has(> p:first-child > input[type='checkbox']:first-child)) {
+    list-style-type: none;
+  }
+
   .safe-markdown :global(a) {
     color: var(--ds-text-link);
     text-decoration: underline;


### PR DESCRIPTION
## What changed

Restores visible list markers for Markdown rendered through `SafeMarkdown`.

`SafeMarkdown` already preserved spacing/indentation for `ul` and `ol`, but Tailwind/global reset styles could leave read-only Markdown lists without visible bullets or numbers. This adds explicit list marker styles for unordered and ordered lists, and ensures `li` elements render as list items.

## Why

Work item descriptions and comments can contain Markdown bullet or numbered lists. In read-only mode, those lists were rendered with indentation but without markers, while the editor view still showed them correctly. This made existing Markdown content look like plain indented text outside edit mode.

This appears to be a regression from `b0068620` (`Preserve work item Markdown at render boundaries`), which introduced `SafeMarkdown` for read-only Markdown rendering in `0.8.7`. That change preserved sanitized Markdown output, but the new read-only renderer did not explicitly restore list marker styles after the global reset, so bullets/numbers disappeared outside edit mode.

## Testing

- `npm run check`
- Verified locally in a deployed Windshift instance with bullet lists in both a work item description and comment.

## Screenshots

Work item description and comment containing bullet points:

<img width="1032" height="978" alt="image" src="https://github.com/user-attachments/assets/102ad2c1-d295-468c-8e69-367be13c344f" />

Same work item when editing the description and comment:

<img width="984" height="1287" alt="image" src="https://github.com/user-attachments/assets/3a08e35c-5f99-4da6-9b63-03ff508ed273" />

Same work item with this fix applied:

<img width="996" height="973" alt="image" src="https://github.com/user-attachments/assets/652a730d-3d4a-4ff3-bdcb-049669834b8c" />
