### PR TITLE
fix(frontend): keep empty list item caret aligned

### DIFF
--- a/frontend/src/lib/editors/MilkdownEditor.svelte
+++ b/frontend/src/lib/editors/MilkdownEditor.svelte
@@ -994,7 +994,7 @@
   }
 
   /* Preserve blank lines from remarkPreserveEmptyLinePlugin */
-  :global(.milkdown-editor .ProseMirror br) {
+  :global(.milkdown-editor .ProseMirror br:not(.ProseMirror-trailingBreak)) {
     display: block;
     content: "";
     margin-top: 0.5rem;


### PR DESCRIPTION
## What changed

Updates the Milkdown editor blank-line CSS so it no longer applies to ProseMirror’s internal trailing break node.

The editor still preserves intentional blank lines, but excludes `br.ProseMirror-trailingBreak` from the custom block-style `<br>` rule.

## Why

When creating a new Markdown bullet item, ProseMirror inserts an internal trailing break into the empty list item so the caret has a place to render. Windshift’s editor CSS was styling all `<br>` elements as block-level blank-line placeholders with extra top margin.

That caused the caret for a new empty bullet point to appear offset/misaligned until text was typed. Once text existed, ProseMirror no longer relied on that trailing break, so the alignment looked normal again.

## Testing

- `fnm exec --using=24.18.0 npm run check`
- Verified locally in a deployed Windshift instance by creating a new empty bullet item in a work item description.

## Screenshots

Caret offset for empty item in bullet list:

<img width="221" height="140" alt="image" src="https://github.com/user-attachments/assets/b431ec40-6513-48a6-ae86-82c229c30b73" />

Caret offset for empty item in numbered list:

<img width="253" height="142" alt="image" src="https://github.com/user-attachments/assets/33a036a3-50d9-4f70-ae46-f09278f2509e" />
 
After this change is applied:

<img width="603" height="188" alt="image" src="https://github.com/user-attachments/assets/775b7de3-0f56-4603-b9c1-bcd80db796e8" />

<img width="227" height="155" alt="image" src="https://github.com/user-attachments/assets/9aae7f34-e953-48c9-a9cd-f50fb6bf2161" />
