### PR TITLE
fix(frontend): open workspace creation from quick access

### DIFF
--- a/frontend/src/lib/widgets/dashboard/QuickAccessWidget.svelte
+++ b/frontend/src/lib/widgets/dashboard/QuickAccessWidget.svelte
@@ -15,6 +15,12 @@
   function go(workspace) {
     navigate(`/workspaces/${workspace.id}`);
   }
+
+  function createWorkspace() {
+    window.dispatchEvent(new CustomEvent('show-create-modal', {
+      detail: { type: 'workspace' },
+    }));
+  }
 </script>
 
 {#if workspaces.length === 0}
@@ -25,7 +31,7 @@
       <button
         class="mt-3 inline-flex items-center gap-1 text-xs font-medium px-2 py-1 rounded"
         style="color: var(--ds-link);"
-        onclick={() => navigate('/workspaces/new')}
+        onclick={createWorkspace}
       >
         <Plus class="w-3.5 h-3.5" /> {t('dashboard.states.createWorkspace')}
       </button>


### PR DESCRIPTION
## Summary

- Open the existing workspace creation modal from the empty Quick Access widget.
- Stop routing `new` through the dynamic `/workspaces/:id` route.

This reuses the same `show-create-modal` event contract as the Workspaces page and onboarding flow.

## Verification

- `npm run check`
- `npm run typecheck`
- `./node_modules/.bin/vitest run` (8 tests passed)
- Independent Claude review found no actionable issues

Fixes #210.
