### PR TITLE
feat: add email_verified mapping to SSO attribute configuration

### DIFF
--- a/internal/database/schema/sso.sql
+++ b/internal/database/schema/sso.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS sso_providers (
 	auto_provision_users BOOLEAN DEFAULT FALSE, -- Create users on first SSO login
 	require_verified_email BOOLEAN DEFAULT TRUE, -- Require email_verified=true from IdP (security)
 	-- Claim/attribute mappings (JSON for flexibility)
-	attribute_mapping TEXT DEFAULT '{"email":"email","name":"name","given_name":"given_name","family_name":"family_name","username":"preferred_username"}',
+	attribute_mapping TEXT DEFAULT '{"email":"email","name":"name","given_name":"given_name","family_name":"family_name","username":"preferred_username","email_verified":"email_verified"}',
 	-- SAML-specific fields
 	saml_idp_metadata_url TEXT,  -- IdP metadata URL for auto-configuration
 	saml_idp_sso_url TEXT,       -- IdP Single Sign-On URL

--- a/internal/database/schema/sso_postgres.sql
+++ b/internal/database/schema/sso_postgres.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS sso_providers (
 	auto_provision_users BOOLEAN DEFAULT FALSE, -- Create users on first SSO login
 	require_verified_email BOOLEAN DEFAULT TRUE, -- Require email_verified=true from IdP (security)
 	-- Claim/attribute mappings (JSON for flexibility)
-	attribute_mapping TEXT DEFAULT '{"email":"email","name":"name","given_name":"given_name","family_name":"family_name","username":"preferred_username"}',
+	attribute_mapping TEXT DEFAULT '{"email":"email","name":"name","given_name":"given_name","family_name":"family_name","username":"preferred_username","email_verified":"email_verified"}',
 	-- SAML-specific fields
 	saml_idp_metadata_url TEXT,  -- IdP metadata URL for auto-configuration
 	saml_idp_sso_url TEXT,       -- IdP Single Sign-On URL

--- a/internal/handlers/sso_saml.go
+++ b/internal/handlers/sso_saml.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -305,11 +306,12 @@ func (h *SSOHandler) samlAssertionToClaims(info *sso.SAMLAssertionInfo, provider
 	attrMap, _ := provider.GetAttributeMap()
 	if attrMap == nil {
 		attrMap = &sso.AttributeMap{
-			Email:      "email",
-			Name:       "name",
-			GivenName:  "given_name",
-			FamilyName: "family_name",
-			Username:   "preferred_username",
+			Email:         "email",
+			EmailVerified: "email_verified",
+			Name:          "name",
+			GivenName:     "given_name",
+			FamilyName:    "family_name",
+			Username:      "preferred_username",
 		}
 	}
 
@@ -367,9 +369,19 @@ func (h *SSOHandler) samlAssertionToClaims(info *sso.SAMLAssertionInfo, provider
 		claims.Username = strings.Split(claims.Email, "@")[0]
 	}
 
-	// SAML lacks a standard verified-email claim. Provider trust decides whether
-	// the asserted email can auto-link an existing account.
+	// SAML lacks a standard verified-email claim. If the IdP asserts the mapped
+	// attribute, honour it; otherwise provider trust decides whether the
+	// asserted email can auto-link an existing account.
 	claims.EmailVerifiedProvided = true
+	if attrMap.EmailVerified != "" {
+		if v := info.GetAttribute(attrMap.EmailVerified); v != "" {
+			// Any value that isn't a recognisable "true" means not verified.
+			if verified, err := strconv.ParseBool(strings.TrimSpace(v)); err == nil {
+				claims.EmailVerified = verified
+			}
+			return claims
+		}
+	}
 	claims.EmailVerified = provider.RequireVerifiedEmail
 
 	return claims

--- a/internal/sso/oidc.go
+++ b/internal/sso/oidc.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -181,15 +182,21 @@ func (s *OIDCService) ExtractClaims(tokens *oidc.Tokens[*oidc.IDTokenClaims], at
 		claims.Email = idTokenClaims.Email
 	}
 
-	// Check if email_verified was explicitly provided by the IdP
-	// The zitadel/oidc library returns a special type that defaults to false
-	// We need to check the raw claims to know if it was actually provided
-	if allClaims != nil {
-		if _, exists := allClaims["email_verified"]; exists {
-			claims.EmailVerifiedProvided = true
-		}
+	// Check if email_verified was explicitly provided by the IdP.
+	// The claim name is configurable via the attribute mapping; it falls back
+	// to the standard OIDC "email_verified" claim. The zitadel/oidc library
+	// returns a special type that defaults to false, so we inspect the raw
+	// claims to know whether the IdP actually sent a value.
+	emailVerifiedClaim := "email_verified"
+	if attributeMap != nil && attributeMap.EmailVerified != "" {
+		emailVerifiedClaim = attributeMap.EmailVerified
 	}
-	claims.EmailVerified = bool(idTokenClaims.EmailVerified)
+	if emailVerifiedValue, exists := allClaims[emailVerifiedClaim]; exists {
+		claims.EmailVerifiedProvided = true
+		claims.EmailVerified = claimToBool(emailVerifiedValue)
+	} else if emailVerifiedClaim == "email_verified" {
+		claims.EmailVerified = bool(idTokenClaims.EmailVerified)
+	}
 
 	// Extract name fields using attribute mapping or standard claims
 	if attributeMap != nil {
@@ -273,4 +280,18 @@ func getClaimString(claims map[string]any, key string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// claimToBool coerces a raw claim value to a bool. IdPs normally send a JSON
+// boolean for email_verified, but some send the string "true"/"false".
+func claimToBool(v any) bool {
+	switch val := v.(type) {
+	case bool:
+		return val
+	case string:
+		b, err := strconv.ParseBool(strings.TrimSpace(val))
+		return err == nil && b
+	default:
+		return false
+	}
 }

--- a/internal/sso/provider.go
+++ b/internal/sso/provider.go
@@ -127,22 +127,24 @@ func scanProviderNoSecret(row interface {
 
 // AttributeMap represents the claim/attribute mapping configuration
 type AttributeMap struct {
-	Email      string `json:"email"`
-	Name       string `json:"name"`
-	GivenName  string `json:"given_name"`
-	FamilyName string `json:"family_name"`
-	Username   string `json:"username"`
+	Email         string `json:"email"`
+	EmailVerified string `json:"email_verified"`
+	Name          string `json:"name"`
+	GivenName     string `json:"given_name"`
+	FamilyName    string `json:"family_name"`
+	Username      string `json:"username"`
 }
 
 // GetAttributeMap parses the attribute mapping JSON
 func (p *SSOProvider) GetAttributeMap() (*AttributeMap, error) {
 	if p.AttributeMapping == "" {
 		return &AttributeMap{
-			Email:      "email",
-			Name:       "name",
-			GivenName:  "given_name",
-			FamilyName: "family_name",
-			Username:   "preferred_username",
+			Email:         "email",
+			EmailVerified: "email_verified",
+			Name:          "name",
+			GivenName:     "given_name",
+			FamilyName:    "family_name",
+			Username:      "preferred_username",
 		}, nil
 	}
 


### PR DESCRIPTION
## Add `email_verified` to the SSO attribute mapping

### Summary

The SSO attribute mapping (`attribute_mapping` on `sso_providers`) let admins remap
`email`, `name`, `given_name`, `family_name`, and `username`, but the verified-email
signal was hardcoded to the standard OIDC `email_verified` claim. IdPs that expose
verification status under a different claim/attribute name had no way to wire it up,
so those users were unnecessarily pushed through in-app email verification.

This adds `email_verified` as a configurable key in the mapping, defaulting to
`"email_verified"` so existing behaviour is unchanged.

### Changes

- **`AttributeMap`** (`internal/sso/provider.go`) — new `EmailVerified` field;
  included in the built-in default map.
- **OIDC** (`internal/sso/oidc.go`) — `ExtractClaims` resolves the verified-email
  claim name from the mapping (falling back to `email_verified`), marks
  `EmailVerifiedProvided` when that claim is present, and parses its value via a new
  `claimToBool` helper that accepts JSON booleans and `"true"`/`"false"` strings.
  When the standard claim name is used and absent, it still falls back to the
  library-parsed value.
- **SAML** (`internal/handlers/sso_saml.go`) — if the IdP asserts the mapped
  attribute, its value is honoured (`strconv.ParseBool`); otherwise the existing
  provider-trust behaviour (`require_verified_email`) applies.
- **Schema** (`internal/database/schema/sso.sql`, `sso_postgres.sql`) —
  `attribute_mapping` column default now includes `"email_verified":"email_verified"`.

### Compatibility

- No migration required — `attribute_mapping` is a free-form JSON blob (validated
  only for size + well-formed JSON). Existing providers with an older mapping simply
  fall back to the `email_verified` default in `GetAttributeMap`.
- Behaviour is identical for any provider that doesn't set the new key.

### Notes / follow-ups

- There is no admin UI field for `attribute_mapping` in `SSOSettings.svelte` today;
  it's API-only. A UI editor for the mapping could be a separate change.

### Testing

- `go build ./...`, `go vet`, and `gofmt` pass. The repo currently has no SSO
  handler/service tests to extend.
