### PR TITLE
fix: complete task paging, filters and parent handling

### DIFF
--- a/internal/wscli/helpers.go
+++ b/internal/wscli/helpers.go
@@ -2,6 +2,7 @@ package wscli
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -146,17 +147,63 @@ func newFiltersWithWorkspace(client *Client, seed map[string]string) (map[string
 
 // applyStatusFilter resolves and adds a status filter (with optional ~negation)
 // to the supplied filters map. It is a no-op when statusVal is empty.
-func applyStatusFilter(filters map[string]string, statusVal string, client *Client) {
+func applyStatusFilter(filters map[string]string, statusVal string, client *Client) error {
 	if statusVal == "" {
-		return
+		return nil
 	}
+	key := "status_id"
 	if isNegatedFilter(statusVal) {
-		resolved := cfg.ResolveStatusWithFallback(stripNegation(statusVal), client)
-		filters["status_id_not"] = resolved
-	} else {
-		resolved := cfg.ResolveStatusWithFallback(statusVal, client)
-		filters["status_id"] = resolved
+		key, statusVal = "status_id_not", stripNegation(statusVal)
 	}
+	resolved := cfg.ResolveStatusWithFallback(statusVal, client)
+	if validStatusIDs(resolved) {
+		filters[key] = resolved
+		return nil
+	}
+	workspaceID, err := strconv.Atoi(filters["workspace_id"])
+	if err != nil || workspaceID <= 0 {
+		return fmt.Errorf("status names require a workspace: use -w, or supply a numeric status ID")
+	}
+	statuses, err := client.GetWorkspaceStatuses(workspaceID)
+	if err != nil {
+		return fmt.Errorf("resolve status: %w", err)
+	}
+	var ids, names []string
+	for _, status := range statuses {
+		names = append(names, status.Name)
+		if strings.EqualFold(status.Name, resolved) {
+			ids = append(ids, strconv.Itoa(status.ID))
+		}
+	}
+	if len(ids) == 0 {
+		return fmt.Errorf("unknown status %q; valid statuses: %s", statusVal, strings.Join(names, ", "))
+	}
+	filters[key] = strings.Join(ids, ",")
+	return nil
+}
+
+func validStatusIDs(value string) bool {
+	for _, part := range strings.Split(value, ",") {
+		id, err := strconv.Atoi(strings.TrimSpace(part))
+		if err != nil || id <= 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func resolveParentID(client *Client, value string) (int, error) {
+	if value == "0" {
+		return 0, nil
+	}
+	id, err := client.ResolveItemID(value)
+	if err != nil {
+		return 0, fmt.Errorf("resolve parent: %w", err)
+	}
+	if id <= 0 {
+		return 0, fmt.Errorf("parent must be an item key, positive ID, or 0 to clear")
+	}
+	return id, nil
 }
 
 // WorkspaceContext holds the commonly fetched workspace configuration data.

--- a/internal/wscli/models.go
+++ b/internal/wscli/models.go
@@ -164,12 +164,13 @@ type ItemCreateRequest struct {
 // carry status_id — status changes go through TransitionRequest on a
 // dedicated endpoint so workflow and condition rules are enforced.
 type ItemUpdateRequest struct {
-	Title        *string        `json:"title,omitempty"`
-	Description  *string        `json:"description,omitempty"`
-	PriorityID   *int           `json:"priority_id,omitempty"`
-	ItemTypeID   *int           `json:"item_type_id,omitempty"`
-	AssigneeID   *int           `json:"assignee_id,omitempty"`
-	ParentID     *int           `json:"parent_id,omitempty"`
+	Title       *string `json:"title,omitempty"`
+	Description *string `json:"description,omitempty"`
+	PriorityID  *int    `json:"priority_id,omitempty"`
+	ItemTypeID  *int    `json:"item_type_id,omitempty"`
+	AssigneeID  *int    `json:"assignee_id,omitempty"`
+	// nil omits the field; a pointer to nil clears it with JSON null.
+	ParentID     **int          `json:"parent_id,omitempty"`
 	MilestoneIDs *[]int         `json:"milestone_ids,omitempty"`
 	IterationID  *int           `json:"iteration_id,omitempty"`
 	ProjectID    *int           `json:"project_id,omitempty"`

--- a/internal/wscli/output.go
+++ b/internal/wscli/output.go
@@ -37,6 +37,9 @@ func (o *Output) printJSON(data any) {
 }
 
 func (o *Output) printTable(data any) {
+	if items, ok := data.(*PaginatedResponse[Item]); ok {
+		warnItemPagination(items)
+	}
 	w := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
 	defer func() { _ = w.Flush() }() //nolint:errcheck // output to stdout
 
@@ -144,6 +147,9 @@ func (o *Output) printTable(data any) {
 }
 
 func (o *Output) printCSV(data any) {
+	if items, ok := data.(*PaginatedResponse[Item]); ok {
+		warnItemPagination(items)
+	}
 	w := csv.NewWriter(stdout)
 	defer w.Flush()
 

--- a/internal/wscli/task.go
+++ b/internal/wscli/task.go
@@ -800,7 +800,11 @@ Examples:
 			if err != nil {
 				return err
 			}
-			req.ParentID = &parentID
+			var parent *int
+			if parentID > 0 {
+				parent = &parentID
+			}
+			req.ParentID = &parent
 			hasChanges = true
 		}
 		if cmd.Flags().Changed("due-date") {

--- a/internal/wscli/task.go
+++ b/internal/wscli/task.go
@@ -73,7 +73,9 @@ Examples:
 			return err
 		}
 
-		applyStatusFilter(filters, statusFilter, client)
+		if err := applyStatusFilter(filters, statusFilter, client); err != nil {
+			return err
+		}
 
 		// Add date filters
 		if err := applyDateFilters(filters, createdFilter, updatedFilter); err != nil {
@@ -130,7 +132,11 @@ var taskListCmd = &cobra.Command{
 	Long: `List tasks with optional filtering.
 
 Examples:
-  ws task ls                              # List all accessible tasks
+  ws task ls                             # First page of accessible tasks
+  ws task ls --all                        # Load all matching pages
+  ws task ls --page 2 --limit 25           # Select a page
+  ws task ls -w PROJ -s "In Progress"      # Workspace status name
+  ws task ls -w PROJ --milestone "Q4"      # Exact milestone name or ID
   ws task ls -s 1                         # Filter by status ID
   ws task ls -s ~done                     # Exclude done status (negation)
   ws task ls --assignee 5                 # Filter by assignee ID
@@ -148,7 +154,23 @@ Examples:
 			return err
 		}
 
-		applyStatusFilter(filters, statusFilter, client)
+		if err := applyStatusFilter(filters, statusFilter, client); err != nil {
+			return err
+		}
+		if taskListMilestone != "" {
+			workspaceID, err := resolveOptionalWorkspace(client)
+			if err != nil {
+				return err
+			}
+			id, err := resolveTaskMilestone(client, taskListMilestone, workspaceID)
+			if err != nil {
+				return err
+			}
+			if id <= 0 {
+				return fmt.Errorf("milestone ID must be positive")
+			}
+			filters["milestone_id"] = strconv.Itoa(id)
+		}
 
 		if assigneeFilter != "" {
 			filters["assignee_id"] = assigneeFilter
@@ -165,7 +187,7 @@ Examples:
 			return err
 		}
 
-		items, err := client.ListItems(filters)
+		items, err := listTaskPage(client, filters, taskListPage, taskListLimit, taskListAll)
 		if err != nil {
 			return fmt.Errorf("failed to list items: %w", err)
 		}
@@ -308,8 +330,14 @@ Examples:
 		if createAssigneeID > 0 {
 			req.AssigneeID = &createAssigneeID
 		}
-		if createParentID > 0 {
-			req.ParentID = &createParentID
+		if cmd.Flags().Changed("parent") {
+			parentID, err := resolveParentID(client, createParent)
+			if err != nil {
+				return err
+			}
+			if parentID > 0 {
+				req.ParentID = &parentID
+			}
 		}
 		if createDueDate != "" {
 			d, err := parseDateFlag("due-date", createDueDate)
@@ -646,7 +674,9 @@ Examples:
 			return err
 		}
 
-		applyStatusFilter(filters, childStatusFilter, client)
+		if err := applyStatusFilter(filters, childStatusFilter, client); err != nil {
+			return err
+		}
 		if childTypeFilter != "" {
 			filters["item_type_id"] = childTypeFilter
 		}
@@ -766,7 +796,11 @@ Examples:
 			hasChanges = true
 		}
 		if cmd.Flags().Changed("parent") {
-			req.ParentID = &editParentID
+			parentID, err := resolveParentID(client, editParent)
+			if err != nil {
+				return err
+			}
+			req.ParentID = &parentID
 			hasChanges = true
 		}
 		if cmd.Flags().Changed("due-date") {
@@ -1054,7 +1088,7 @@ var (
 	createPriorityID   int
 	createStatusID     int
 	createAssigneeID   int
-	createParentID     int
+	createParent       string
 	createDueDate      string
 	createStartDate    string
 	createEndDate      string
@@ -1068,7 +1102,7 @@ var (
 	editTypeStatusID int
 	editPriorityID   int
 	editAssigneeID   int
-	editParentID     int
+	editParent       string
 	editDueDate      string
 	editStartDate    string
 	editEndDate      string
@@ -1093,6 +1127,11 @@ func init() {
 	taskCmd.AddCommand(taskHistoryCmd)
 
 	// List filters
+	taskListCmd.Flags().IntVar(&taskListPage, "page", 1, "result page (starts at 1)")
+	taskListCmd.Flags().IntVar(&taskListLimit, "limit", 50, "results per page (1-100)")
+	taskListCmd.Flags().BoolVar(&taskListAll, "all", false, "fetch every result page")
+	taskListCmd.Flags().StringVar(&taskListMilestone, "milestone", "", "filter by milestone name or ID")
+	taskListCmd.MarkFlagsMutuallyExclusive("all", "page")
 	taskMineCmd.Flags().StringVarP(&statusFilter, "status", "s", "", "filter by status (use ~status to exclude)")
 	taskMineCmd.Flags().StringVar(&createdFilter, "created", "", "filter by creation date (today, week, month, year, or -Nd)")
 	taskMineCmd.Flags().StringVar(&updatedFilter, "updated", "", "filter by update date (today, week, month, year, or -Nd)")
@@ -1128,7 +1167,7 @@ func init() {
 	taskEditCmd.Flags().IntVar(&editTypeStatusID, "type-status", 0, "target status ID when changing to a type with a different workflow")
 	taskEditCmd.Flags().IntVar(&editPriorityID, "priority", 0, "priority ID")
 	taskEditCmd.Flags().IntVar(&editAssigneeID, "assignee", 0, "assignee user ID")
-	taskEditCmd.Flags().IntVar(&editParentID, "parent", 0, "parent item ID")
+	taskEditCmd.Flags().StringVar(&editParent, "parent", "", "parent item key or ID (0 clears parent)")
 	taskEditCmd.Flags().StringVar(&editDueDate, "due-date", "", "due date (YYYY-MM-DD)")
 	taskEditCmd.Flags().StringVar(&editStartDate, "start-date", "", "start date (YYYY-MM-DD)")
 	taskEditCmd.Flags().StringVar(&editEndDate, "end-date", "", "end date (YYYY-MM-DD)")
@@ -1144,7 +1183,7 @@ func init() {
 	taskCreateCmd.Flags().IntVar(&createPriorityID, "priority", 0, "priority ID")
 	taskCreateCmd.Flags().IntVar(&createStatusID, "status", 0, "status ID")
 	taskCreateCmd.Flags().IntVar(&createAssigneeID, "assignee", 0, "assignee user ID")
-	taskCreateCmd.Flags().IntVar(&createParentID, "parent", 0, "parent item ID")
+	taskCreateCmd.Flags().StringVar(&createParent, "parent", "", "parent item key or ID")
 	taskCreateCmd.Flags().StringVar(&createDueDate, "due-date", "", "due date (YYYY-MM-DD)")
 	taskCreateCmd.Flags().StringVar(&createStartDate, "start-date", "", "start date (YYYY-MM-DD)")
 	taskCreateCmd.Flags().StringVar(&createEndDate, "end-date", "", "end date (YYYY-MM-DD)")

--- a/internal/wscli/task_pagination.go
+++ b/internal/wscli/task_pagination.go
@@ -1,0 +1,114 @@
+package wscli
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+var (
+	taskListPage      int
+	taskListLimit     int
+	taskListAll       bool
+	taskListMilestone string
+)
+
+func warnItemPagination(items *PaginatedResponse[Item]) {
+	if items == nil {
+		return
+	}
+	total := items.Pagination.TotalItems
+	if total == 0 {
+		total = items.Pagination.Total
+	}
+	if total == 0 {
+		total = items.Total
+	}
+	if total > len(items.Data) {
+		_, _ = fmt.Fprintf(stderr, "Showing %d of %d items (page %d/%d); use --page/--limit or task ls --all for more.\n", len(items.Data), total, items.Pagination.Page, items.Pagination.TotalPages)
+	}
+}
+
+func listTaskPage(client *Client, filters map[string]string, page, limit int, all bool) (*PaginatedResponse[Item], error) {
+	if page < 1 || limit < 1 || limit > 100 {
+		return nil, fmt.Errorf("--page must be positive and --limit must be between 1 and 100")
+	}
+	params := make(map[string]string, len(filters)+2)
+	for key, value := range filters {
+		params[key] = value
+	}
+	params["page_size"] = strconv.Itoa(limit)
+	var combined []Item
+	seen := make(map[int]bool)
+	for {
+		params["page"] = strconv.Itoa(page)
+		response, err := client.ListItems(params)
+		if err != nil {
+			return nil, err
+		}
+		if !all {
+			return response, nil
+		}
+		if response.Pagination.Page != page || response.Pagination.TotalPages < 0 ||
+			(response.Pagination.TotalPages == 0 && (len(response.Data) > 0 || response.Pagination.TotalItems > 0)) {
+			return nil, fmt.Errorf("invalid pagination returned for page %d", page)
+		}
+		before := len(combined)
+		for _, item := range response.Data {
+			if !seen[item.ID] {
+				seen[item.ID] = true
+				combined = append(combined, item)
+			}
+		}
+		if page >= response.Pagination.TotalPages {
+			if combined == nil {
+				combined = []Item{}
+			}
+			return &PaginatedResponse[Item]{Data: combined, Pagination: PaginationMeta{Page: 1, PageSize: len(combined), TotalItems: len(combined), TotalPages: 1}}, nil
+		}
+		if len(combined) == before {
+			return nil, fmt.Errorf("pagination made no progress on page %d; retry the query", page)
+		}
+		page++
+	}
+}
+
+// A name must identify exactly one milestone in the selected workspace.
+// Never turn a misspelled filter into an unfiltered or fuzzy-matched list.
+func resolveTaskMilestone(client *Client, value string, workspaceID *int) (int, error) {
+	if id, err := strconv.Atoi(value); err == nil {
+		return id, nil
+	}
+	if workspaceID == nil {
+		return 0, fmt.Errorf("milestone names require a workspace: use -w, or supply a numeric milestone ID")
+	}
+	match := 0
+	for page := 1; ; page++ {
+		response, err := client.ListMilestonesInWorkspace(*workspaceID, map[string]string{"page": strconv.Itoa(page), "page_size": "100"})
+		if err != nil {
+			return 0, fmt.Errorf("resolve milestone: %w", err)
+		}
+		if response.Pagination.Page != page || response.Pagination.TotalPages < 0 ||
+			(response.Pagination.TotalPages == 0 && (len(response.Data) > 0 || response.Pagination.TotalItems > 0)) {
+			return 0, fmt.Errorf("invalid milestone pagination returned for page %d", page)
+		}
+		for _, milestone := range response.Data {
+			if strings.EqualFold(milestone.Name, value) {
+				if match != 0 && match != milestone.ID {
+					return 0, fmt.Errorf("milestone name %q is ambiguous; use its numeric ID", value)
+				}
+				match = milestone.ID
+			}
+		}
+		if page >= response.Pagination.TotalPages {
+			break
+		}
+		if len(response.Data) == 0 {
+			return 0, fmt.Errorf("milestone pagination made no progress on page %d", page)
+		}
+	}
+	if match == 0 {
+		return 0, fmt.Errorf("milestone not found: %s", value)
+	}
+	return match, nil
+}

--- a/internal/wscli/task_pagination.go
+++ b/internal/wscli/task_pagination.go
@@ -61,6 +61,9 @@ func listTaskPage(client *Client, filters map[string]string, page, limit int, al
 			}
 		}
 		if page >= response.Pagination.TotalPages {
+			if len(combined) != response.Pagination.TotalItems {
+				return nil, fmt.Errorf("incomplete pagination: received %d of %d items; retry the query", len(combined), response.Pagination.TotalItems)
+			}
 			if combined == nil {
 				combined = []Item{}
 			}

--- a/internal/wscli/task_pagination.go
+++ b/internal/wscli/task_pagination.go
@@ -25,7 +25,7 @@ func warnItemPagination(items *PaginatedResponse[Item]) {
 		total = items.Total
 	}
 	if total > len(items.Data) {
-		_, _ = fmt.Fprintf(stderr, "Showing %d of %d items (page %d/%d); use --page/--limit or task ls --all for more.\n", len(items.Data), total, items.Pagination.Page, items.Pagination.TotalPages)
+		_, _ = fmt.Fprintf(stderr, "Showing %d of %d items (page %d/%d); task ls supports --page/--limit and --all (reapply the relevant filters).\n", len(items.Data), total, items.Pagination.Page, items.Pagination.TotalPages)
 	}
 }
 
@@ -46,12 +46,12 @@ func listTaskPage(client *Client, filters map[string]string, page, limit int, al
 		if err != nil {
 			return nil, err
 		}
-		if !all {
-			return response, nil
-		}
 		if response.Pagination.Page != page || response.Pagination.TotalPages < 0 ||
 			(response.Pagination.TotalPages == 0 && (len(response.Data) > 0 || response.Pagination.TotalItems > 0)) {
 			return nil, fmt.Errorf("invalid pagination returned for page %d", page)
+		}
+		if !all {
+			return response, nil
 		}
 		before := len(combined)
 		for _, item := range response.Data {


### PR DESCRIPTION
Make task listing explicit about pagination: `--page`, `--limit` and `--all` support complete retrieval, preserve filters and reject inconsistent page responses. Table/CSV output warns on stderr when results are partial.

Status names resolve in the selected workspace, including negation. Milestone names require an exact, unambiguous workspace match across all pages. Parent keys work in create/edit; `task edit --parent 0` sends JSON null to remove the parent, while omission preserves it.

Verified: the complete external CLI test package, focused task tests with the race detector, CLI `go vet` and `go test ./cmd/ws`. Real HTTP regression tests on SQLite verify persisted parent removal and preservation, not just a stub response. These tests are on [the companion test branch](https://github.com/Optic00/core-tests/tree/codex/api-v2-suite-migration), whose wider migration remains incomplete.
